### PR TITLE
Add Visual Studio Code to list of apps written

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ Some good apps written with Electron.
 - [Avocode](http://avocode.com) - Share design and collaborate.
 - [Pixate](http://www.pixate.com) - Mobile interaction designer.
 - [Spark Dev](https://www.spark.io/dev) - Professional IDE for Spark.
+- [Visual Studio Code](https://code.visualstudio.com/) - Free cross-platform IDE from Microsoft.
 
 
 ## Boilerplates


### PR DESCRIPTION
Microsoft announced it yesterday at their Build event. They mention towards the bottom of this page that it's built with electron: https://code.visualstudio.com/Docs