### PR TITLE
Adds electron-cookies to list of components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Some good apps written with Electron.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the OS X window titlebar.
 - [chrome-tabs](https://github.com/adamschwartz/chrome-tabs) - Chrome like tabs.
 - [menubar](https://github.com/maxogden/menubar) - High-level way to create a menubar app.
+- [cookies](https://github.com/hstove/electron-cookies) - Adds support for `document.cookie`.
 
 
 ## Tutorials


### PR DESCRIPTION
Thanks for this resource! Perhaps "Components" isn't the best section, but I didn't think any of the others were a better fit.