### PR TITLE
electron-packager works on Linux & Windows as of last week

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Some good apps written with Electron.
 
 ## Tools
 
-- [electron-packager](https://github.com/maxogden/electron-packager) - Package and distribute your app. *(OS X only for now)*
+- [electron-packager](https://github.com/maxogden/electron-packager) - Package and distribute your app.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 


### PR DESCRIPTION
Linux support was added in 3.2.0. Windows support was added in 3.4.0.