### PR TITLE
Update readme.md: add electron-window

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Some good apps written with Electron.
 - [chrome-tabs](https://github.com/adamschwartz/chrome-tabs) - Chrome like tabs.
 - [menubar](https://github.com/maxogden/menubar) - High-level way to create a menubar app.
 - [cookies](https://github.com/hstove/electron-cookies) - Adds support for `document.cookie`.
+- [window](https://github.com/jprichardson/electron-window) - Easily create windows, pass arguments to renderer, and manage global window references.
 
 
 ## Tutorials


### PR DESCRIPTION
This PR adds `electron-window` to the `components` section.