### PR TITLE
Add electron-react-boilerplate.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Some good apps written with Electron.
 - [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) (by sindresorhus) - Boilerplate to kickstart creating an app.
 - [generator-electron](https://github.com/sindresorhus/generator-electron) - Scaffold out an app boilerplate.
 - [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) (by szwacz) - Comprehensive boilerplate which even generates installers.
+- [chentsulin/electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate) - Application boilerplate based on react, react-router, webpack and react-hot-loader for rapid application development.
 
 
 ## Tools


### PR DESCRIPTION
It's a boilerplate for easily getting started with react-hot reload development. Hope it can help people work on with react and wepack (target 'atom').  
[chentsulin/electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate)