### PR TITLE
Add electron-builder and electron-updater to the tools category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,11 @@ Some good apps written with Electron.
 ## Tools
 
 - [electron-packager](https://github.com/maxogden/electron-packager) - Package and distribute your Electron app for OS X, Linux and Windows (.app, .exe, etc).
+- [electron-builder](https://github.com/loopline-systems/electron-builder) - Build installers for Windows and OS X from Windows, Linux, or OS X.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 - [electron-gh-release](https://github.com/jenslind/electron-gh-releases) - Electron auto-update by releasing on GitHub.
+- [electron-updater](https://github.com/evolvelabs/electron-updater) - A cross platform auto-updater, leveraging NPM to deploy updates.
 - [electron-download](https://github.com/maxogden/electron-download) - Download the Electron release zip from GitHub for a particular architecture and platform.
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features.
 - [fix-path](https://github.com/sindresorhus/fix-path) - Fix the $PATH on OS X when run from a GUI app. Useful when spawning a child process.

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Some good apps written with Electron.
 ## Tools
 
 - [electron-packager](https://github.com/maxogden/electron-packager) - Package and distribute your Electron app for OS X, Linux and Windows (.app, .exe, etc).
-- [electron-builder](https://github.com/loopline-systems/electron-builder) - Build installers.
+- [electron-builder](https://github.com/loopline-systems/electron-builder) - Create installers.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 - [electron-gh-release](https://github.com/jenslind/electron-gh-releases) - Electron auto-update by releasing on GitHub.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Some good apps written with Electron.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 - [electron-gh-release](https://github.com/jenslind/electron-gh-releases) - Electron auto-update by releasing on GitHub.
-- [electron-updater](https://github.com/evolvelabs/electron-updater) - A cross platform auto-updater, leveraging npm for update deployment.
+- [electron-updater](https://github.com/evolvelabs/electron-updater) - Auto-updater leveraging npm to deploy updates.
 - [electron-download](https://github.com/maxogden/electron-download) - Download the Electron release zip from GitHub for a particular architecture and platform.
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features.
 - [fix-path](https://github.com/sindresorhus/fix-path) - Fix the $PATH on OS X when run from a GUI app. Useful when spawning a child process.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Some good apps written with Electron.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 - [electron-gh-release](https://github.com/jenslind/electron-gh-releases) - Electron auto-update by releasing on GitHub.
-- [electron-updater](https://github.com/evolvelabs/electron-updater) - A cross platform auto-updater, leveraging NPM to deploy updates.
+- [electron-updater](https://github.com/evolvelabs/electron-updater) - A cross platform auto-updater, leveraging npm for update deployment.
 - [electron-download](https://github.com/maxogden/electron-download) - Download the Electron release zip from GitHub for a particular architecture and platform.
 - [electron-debug](https://github.com/sindresorhus/electron-debug) - Adds useful debug features.
 - [fix-path](https://github.com/sindresorhus/fix-path) - Fix the $PATH on OS X when run from a GUI app. Useful when spawning a child process.

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Some good apps written with Electron.
 ## Tools
 
 - [electron-packager](https://github.com/maxogden/electron-packager) - Package and distribute your Electron app for OS X, Linux and Windows (.app, .exe, etc).
-- [electron-builder](https://github.com/loopline-systems/electron-builder) - Build installers for Windows and OS X from Windows, Linux, or OS X.
+- [electron-builder](https://github.com/loopline-systems/electron-builder) - Build installers.
 - [electron-prebuilt](https://github.com/mafintosh/electron-prebuilt) - Install prebuilt Electron binaries for command-line use using npm.
 - [electron-rebuild](https://github.com/paulcbetts/electron-rebuild) - Rebuild native io.js modules against the currently installed Electron version.
 - [electron-gh-release](https://github.com/jenslind/electron-gh-releases) - Electron auto-update by releasing on GitHub.


### PR DESCRIPTION
I added `electron-builder` right below the packager because they are closely related. I added `electron-updater` below `electron-gh-release` since it was an updater also and was there first.

It's arguable that since there are two updaters now that a new category could be formed, (or sub category for which I have no formatting references). What do you think?