### PR TITLE
Add unofficial Google music app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Some good apps written with Electron.
 - [Blox Party](https://github.com/kvnneff/bloxparty) - Multiplayer Tetris game.
 - [Trendy](https://rhysd.github.io/Trendy/) - Trending GitHub repos in your menubar.
 - [N1](https://github.com/nylas/N1) - Extensible email client.
+- [google-music-electron](https://github.com/twolfson/google-music-electron) - Unofficial Google music app.
 
 ### Closed Source
 


### PR DESCRIPTION
Link to the package: [google-music-electron](https://github.com/twolfson/google-music-electron).

This package is currently maintained and will be of use to some of the lovers of Google music.