### PR TITLE
Add Spreaker Studio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Some good apps written with Electron.
 - [Stremio](http://www.strem.io) - Next generation media center.
 - [RESTer](http://getrester.com) - Easy and beautiful way to test your APIs and servers.
 - [Typetalk](http://www.typetalk.in) - Share and discuss ideas with your team through instant messaging.
-
+- [Spreaker Studio](https://www.spreaker.com/desktop-studio/download) - Audio recording and broadcasting app from Spreaker.
 
 ## Boilerplates
 


### PR DESCRIPTION
Today Spreaker released its Studio desktop app (an audio recording and broadcasting tool built with Electron + React.js). I'm one of the developers.