### PR TITLE
add BearyChat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ Some good apps written with Electron.
 - [Pubu](https://pubu.im) - Real-time chat for team communication. *(Chinese)*
 - [Pingendo](http://pingendo.com) - The simplest app for Bootstrap prototyping.
 - [Spreaker Studio](https://www.spreaker.com/download) - Audio recording and broadcasting.
+- [BearyChat](https://bearychat.com) - A messaging service that brings your team on the same page.
 
 ## Boilerplates
 


### PR DESCRIPTION
BearyChat is a messaging service in China that brings your team on the same page. [This](https://download.bearychat.com/apps/mac) is where you can download the app.
Here is a screenshot of osx Frameworks folder of this app, which obviously proves that it's built with Electron.
![image](https://cloud.githubusercontent.com/assets/2618847/10512006/e264d118-736f-11e5-87a3-c23b01163ec4.png)
