### PR TITLE
Add Codesigning article

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ Some good apps written with Electron.
 
 - [Electron Fundamentals](http://maxogden.com/electron-fundamentals.html)
 - [Building a desktop application with Electron](https://medium.com/@bojzi/building-a-desktop-application-with-electron-204203eeb658)
+- [Signing/Codesigning your app for OSX](http://jbavari.github.io/blog/2015/08/14/codesigning-electron-applications/)
 
 
 ## Videos


### PR DESCRIPTION
Anyone building an Electron app for OSX will need to do this Codesigning stuff. It is not easy, especially if you are totally new to the world of Apple process or app signing in general. This article was helpful and contained a lot of great links. 