### PR TITLE
add electron-drag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Some good apps written with Electron.
 - [Geojsonapp](https://github.com/mick/geojsonapp) - Preview GeoJSON locally.
 - [electron-detach](https://github.com/parro-it/electron-detach) - Restart an Electron app as a detached process.
 - [electron-localshortcut](https://github.com/parro-it/electron-localshortcut) - Add keyboard shortcuts locally to a window.
+- [electron-drag](https://github.com/kapetan/electron-drag) - Window dragging for electron applications.
 
 
 ## Components


### PR DESCRIPTION
[electron-drag](https://github.com/kapetan/electron-drag)

> Improved window dragging for Electron applications.

> Framless windows can be dragged using the -webkit-app-region css property, but this disables all regular dom events and user interactions with the affected element, which makes it hard to emulate a native-like title bar in the application, as it's not possible to capture double clicks for maximizing the window.

> A workaround is to use a pure javascript solution, but dragging only works well when moving the mouse in less than normal speed, else the mouse pointer will move outside the window area and no events will be received by the dom.

> This module uses osx-mouse or win-mouse modules for tracking the mouse position on the entire screen, and thereby enabling consistent window dragging, while the affected element is still able to receive dom events.