### PR TITLE
Add Sync messenger by Wantedly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Some good apps written with Electron.
 - [GitKraken](http://www.gitkraken.com) - An intuitive, fast, and beautiful Git client.
 - [Wire](https://wire.com) - Beautiful and secure messenger and calling app.
 - [Boost](https://b00st.io) - Simple and beautiful Markdown note app for developers.
+- [Sync](https://www.wantedly.com/sync) - A group messaging app for successful teams *(Japanese)*
 
 
 ## Boilerplates


### PR DESCRIPTION
Sync is a group messaging app for users of Wantedly (business SNS in Japan and South East Asia), which can be downloaded from https://www.wantedly.com/sync

Here is evidence of Mac desktop version being built with Electron:

![screenshot 2015-11-12 23 24 12](https://cloud.githubusercontent.com/assets/43811/11120630/8cc8ecea-8994-11e5-9040-311a851bbf26.png)