### PR TITLE
Add KeeWeb

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ Some good apps written with Electron.
 - [MarkRight](https://github.com/dvcrn/markright) - GitHub flavored Markdown editor with live preview.
 - [SpaceRadar](https://github.com/zz85/space-radar) - Interactive disk space and memory visualization.
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Free cross-platform IDE from Microsoft.
+- [KeeWeb](https://github.com/antelle/keeweb) - Unofficial KeePass web app.
 
 
 ### Closed Source


### PR DESCRIPTION
[KeeWeb](https://github.com/antelle/keeweb) is an unofficial KeePass app which can work as a web app or desktop. Desktop apps for Mac, Windows and Linux are created with Electron.
All app features [on one page](https://github.com/antelle/keeweb/blob/master/features.md#keeweb-features).
App screenshot:
<img width="750" alt="68747470733a2f2f686162726173746f726167652e6f72672f66696c65732f6266622f3531652f6438642f62666235316564386431393834376438616662383237633466626666376464352e706e67" src="https://cloud.githubusercontent.com/assets/633557/11323919/0f0e4e58-9132-11e5-8e2a-f1eea2ac7ad4.png">