### PR TITLE
Add a Mongotron link to open source projects.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Some good apps written with Electron.
 - [SpaceRadar](https://github.com/zz85/space-radar) - Interactive disk space and memory visualization.
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Free cross-platform IDE from Microsoft.
 - [KeeWeb](https://github.com/antelle/keeweb) - Unofficial KeePass app.
+- [Mongotron](https://github.com/officert/mongotron) - MongoDB management tool.
 
 
 ### Closed Source


### PR DESCRIPTION
https://github.com/officert/mongotron

Mongotron is an open-source Mongo DB database management tool. I built it after being frustrated with the current set of MongoDB management tools available. The project is still in its infancy, though it's becoming a very robust tool. I'd like it to be included in this list because it's an open-source project built on Electron, and I believe it to be a good example of the kinds of things that can be built using Electron.