### PR TITLE
Add electron-har

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Some good apps written with Electron.
 - [debug-menu](https://github.com/parro-it/debug-menu) - Chrome-like "inspect element" context-menu.
 - [electron-sudo](https://github.com/automation-stack/electron-sudo) - Subprocesses with administrative privileges.
 - [electron-dl](https://github.com/sindresorhus/electron-dl) - Simplified file downloads.
+- [electron-har](https://github.com/shyiko/electron-har) - A command-line tool for generating HTTP Archive (HAR).
 
 
 ## Components


### PR DESCRIPTION
A command-line tool for generating HTTP Archive (HAR).

> The goal was to have a utility that would be simple (both in terms of implementation and UX), reliable (e.g. phantomjs/slimerjs-based solutions have troubles with accurate “bodySize” reporting when gzip is used (among other things)) and would not require complicated setup (like installing real browsers). Tested on Mac OS X and Linux.