### PR TITLE
improve description of hokein/electron-sample-apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Some good apps written with Electron.
 - [Vmd](https://github.com/yoshuawuyts/vmd) - Preview Markdown files.
 - [Kyoku](https://github.com/cheeaun/kyoku) - Displays current iTunes song.
 - [GReader](https://github.com/Nekle/greader) - Collect and read offline readme files of GitHub repos.
-- [Sample apps](https://github.com/hokein/electron-sample-apps) - Various sample apps.
+- [Sample apps](https://github.com/hokein/electron-sample-apps) - Sample apps to illustrate the usage of Electron APIs.
 - [Koko](https://github.com/hachibasu/koko) - IRC client.
 - [Leanote](https://github.com/leanote/desktop-app) - Cloud notepad.
 - [Snapper](https://github.com/prt2121/Snapper) - Screen capturing & recording for Android devices.
@@ -74,7 +74,6 @@ Some good apps written with Electron.
 - [Sqlectron](https://github.com/sqlectron/sqlectron-gui) - SQL client.
 - [docker-indicator](https://github.com/khornberg/docker-indicator) - Unofficial Docker menubar app.
 - [Light Table](https://github.com/LightTable/LightTable) - Code editor with instant feedback.
-- [Electron Sample Apps](https://github.com/hokein/electron-sample-apps) - Sample apps to illustrate the usage of Electron APIs.
 
 
 ### Closed Source

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Some good apps written with Electron.
 - [Sqlectron](https://github.com/sqlectron/sqlectron-gui) - SQL client.
 - [docker-indicator](https://github.com/khornberg/docker-indicator) - Unofficial Docker menubar app.
 - [Light Table](https://github.com/LightTable/LightTable) - Code editor with instant feedback.
+- [Electron Sample Apps](https://github.com/hokein/electron-sample-apps) - Sample apps.
 
 
 ### Closed Source

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Some good apps written with Electron.
 - [Sqlectron](https://github.com/sqlectron/sqlectron-gui) - SQL client.
 - [docker-indicator](https://github.com/khornberg/docker-indicator) - Unofficial Docker menubar app.
 - [Light Table](https://github.com/LightTable/LightTable) - Code editor with instant feedback.
-- [Electron Sample Apps](https://github.com/hokein/electron-sample-apps) - Sample apps.
+- [Electron Sample Apps](https://github.com/hokein/electron-sample-apps) - Sample apps to illustrate the usage of Electron APIs.
 
 
 ### Closed Source


### PR DESCRIPTION
@hokein just added a [desktop capture API](https://github.com/atom/electron/pull/2963) to electron. The commits refer to the [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) repo, which contains working demos for:

- camera
- client-certificate
- cookies
- crash-report
- desktop-capture
- file-explorer
- frameless-window
- menus
- mini-code-edit
- mp3-encoder
- notifications
- pepper-flash-plugin
- power-save-blocker
- printing
- spellchecking
- tray
- webgl
- webview