### PR TITLE
Add Tubehead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Some good apps written with Electron.
 - [Sqlectron](https://github.com/sqlectron/sqlectron-gui) - SQL client.
 - [docker-indicator](https://github.com/khornberg/docker-indicator) - Unofficial Docker menubar app.
 - [Light Table](https://github.com/LightTable/LightTable) - Code editor with instant feedback.
+- [Tubehead](https://github.com/makotot/Tubehead) - YouTube music player as OSX app hardly inspired by musictonic.
 
 
 ### Closed Source


### PR DESCRIPTION
YouTube music player as OSX app hardly inspired by [Musictonic](http://musictonic.com/).