### PR TITLE
Add Yeobara

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Some good apps written with Electron.
 - [Light Table](https://github.com/LightTable/LightTable) - Code editor with instant feedback.
 - [Tubehead](https://github.com/makotot/Tubehead) - YouTube music player in your menubar.
 - [Chrome DevTools](https://github.com/auchenberg/chrome-devtools-app) - Chrome DevTools packaged as an app.
-
+- [Yeobara Desktop](https://github.com/yeobara/yeobara-desktop) - Meetup Check-in app with [Eddystone](https://github.com/google/eddystone).
 
 ### Closed Source
 


### PR DESCRIPTION
Yeobara is meetup auto check-in desktop app using by Eddystone running top on the Electron. It's not a production but I think it is one of the good sample app for Eddystone, Polymer Starter Kit that show how to use both of them tech.