### PR TITLE
Add Proton

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,9 +83,6 @@ Some good apps written with Electron.
 - [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
 - [James](https://github.com/uxebu/james) - HTTP proxy to view and intercept browser requests.
 - [DTCP](https://github.com/alchen/DTCP) - Twitter client.
-- [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
-- [James](https://github.com/uxebu/james) - HTTP proxy to view and intercept browser requests.
-- [DTCP](https://github.com/alchen/DTCP) - Twitter client.
 
 
 ### Closed Source

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,13 @@ Some good apps written with Electron.
 - [Yeobara](https://github.com/yeobara/yeobara-desktop) - Meetup check-in with beacon.
 - [SmartMirror](https://github.com/evancohen/smart-mirror) - Voice controlled smart mirror.
 - [Medis](https://github.com/luin/medis) - Redis database management.
+- [Proton](https://github.com/steventhanna/proton) - A pure JS Markdown editor with live rendering
+- [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
+- [James](https://github.com/uxebu/james) - HTTP proxy to view and intercept browser requests.
+- [DTCP](https://github.com/alchen/DTCP) - Twitter client.
+- [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
+- [James](https://github.com/uxebu/james) - HTTP proxy to view and intercept browser requests.
+- [DTCP](https://github.com/alchen/DTCP) - Twitter client.
 
 
 ### Closed Source
@@ -138,6 +145,10 @@ Some good apps written with Electron.
 - [electron-sudo](https://github.com/automation-stack/electron-sudo) - Subprocesses with administrative privileges.
 - [electron-dl](https://github.com/sindresorhus/electron-dl) - Simplified file downloads.
 - [electron-har](https://github.com/shyiko/electron-har) - Command-line tool for generating HTTP Archive (HAR).
+- [electron-window-state](https://github.com/mawie81/electron-window-state) - Save and restore window sizes and positions.
+- [nuts](https://github.com/GitbookIO/nuts) - Releases server with auto-updater and GitHub as a backend.
+- [electrify](https://github.com/arboleya/electrify) - Package Meteor apps.
+- [nativefier](https://github.com/jiahaog/nativefier) - Create an app of any website.
 
 
 ## Components


### PR DESCRIPTION
Added [Proton](https://github.com/steventhanna/proton), a stand-alone application compatible with OSX, Windows, and Linux to quickly view, and edit Markdown files, as well as convert them into HTML, and PDF's.  

Features include
- Syntax Highlighting
- Hackable - Pure JS, HTML, and CSS
- Export to HTML and PDF
- Created using the feature rich [Ace Editor](https://ace.c9.io/#nav=about)
![Proton Screenshot](https://camo.githubusercontent.com/3ea806bad32d9db76f55dcd8cc760ae1b5b2433e/687474703a2f2f73746576656e7468616e6e612e6769746875622e696f2f70726f746f6e2f70726f746f6e2d696d6167652e706e67)

This app is completely open-source, with an initial release in October.

The latest release can be found [here](https://github.com/steventhanna/proton/releases/tag/v0.1.1), as the corresponding binaries are over the file limit of 10MB.  