### PR TITLE
Add electron-window-state

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Some good apps written with Electron.
 - [electron-sudo](https://github.com/automation-stack/electron-sudo) - Subprocesses with administrative privileges.
 - [electron-dl](https://github.com/sindresorhus/electron-dl) - Simplified file downloads.
 - [electron-har](https://github.com/shyiko/electron-har) - Command-line tool for generating HTTP Archive (HAR).
+- [electron-window-state](https://github.com/mawie81/electron-window-state) - Save and restore window sizes and positions.
 
 
 ## Components


### PR DESCRIPTION
electron-window-state is a small library to save and restore sizes and positions of Electron windows.
https://github.com/mawie81/electron-window-state