### PR TITLE
Add nativefier

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Some good apps written with Electron.
 - [electron-window-state](https://github.com/mawie81/electron-window-state) - Save and restore window sizes and positions.
 - [nuts](https://github.com/GitbookIO/nuts) - Releases server with auto-updater and GitHub as a backend.
 - [electrify](https://github.com/arboleya/electrify) - Package Meteor apps.
-
+- [nativefier](https://github.com/jiahaog/nativefier) - Wrap any web page natively without even thinking, across Windows, OSX and Linux
 
 ## Components
 


### PR DESCRIPTION
Wrap any web page natively without even thinking with [Nativefier](https://github.com/jiahaog/nativefier)
> Nativefier is a command line tool that allows you to easily create a desktop application for any web site with succinct and minimal configuration. Apps are wrapped into an OS executable (`.app`, `.exe`, etc.) for use on Windows, OSX and Linux.
