### PR TITLE
Add DTCP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Some good apps written with Electron.
 - [Medis](https://github.com/luin/medis) - Redis database management.
 - [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
 - [James](https://github.com/uxebu/james) - HTTP proxy to view and intercept browser requests.
+- [DTCP](https://github.com/alchen/DTCP) - Twitter client.
 
 
 ### Closed Source


### PR DESCRIPTION
[It's a Twitter client based on Electron.](https://github.com/alchen/DTCP)

Last time -- back in June -- it was too early to submit, but it should be quite usable now.