### PR TITLE
Add Electronic WeChat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Some good apps written with Electron.
 - [alienbox](http://a9.io/alienbox/) - Reddit inbox & notifier in your menubar.
 - [tweet-rec](https://github.com/midnightSuyama/tweet-rec) - Tweet recording player.
 - [Snippet Bar](https://github.com/teesloane/snippet-bar) - Copy-paste & re-use text snippets in your menubar.
-
+- [Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) - A better WeChat client on Mac OS X and Linux.
 
 ### Closed Source
 


### PR DESCRIPTION
Electronic WeChat. A better WeChat client on Mac OS X and Linux