### PR TITLE
Added SIV Image Viewer to closed source projects listing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Some good apps written with Electron.
 - [Sync](https://www.wantedly.com/sync) - Team group messaging. *(Japanese)*
 - [Caret](http://caret.io) - Markdown editor.
 - [Postman](https://www.getpostman.com) - Create and send HTTP requests.
-
+- [SIV](http://www.integritytools.com/siv/) - An extensible image viewer.
 
 ## Boilerplates
 


### PR DESCRIPTION
**Project site and description:**
- http://www.integritytools.com/siv/
- SIV is an extensible image viewer built for those who review, analyze, and gather information from images.
- SIV stands for SIV Image Viewer (its a recursive acronym)

**Evidence of SIV being built with Electron**
 - I'm not sure what sort of evidence you're looking for, but here's a snapshot of SIV's package.json which shows `electron-prebuilt` as a dependency. If you want I can also show you the script I use to build the project for Windows.
![siv-package-dot-json](https://cloud.githubusercontent.com/assets/7446702/13561047/245c907a-e3e5-11e5-8e89-c2fe1a42ffc1.png)

**Why should SIV be included?**
 - I think people should be aware that you can build a small business off of electron - that it isn't just for large corporations, VC-backed startups,  and open source tools.