### PR TITLE
Add Google Play Music Desktop Player

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ Some good apps written with Electron.
 - [FromScratch](https://github.com/kilian/fromscratch) - Autosaving scratchpad.
 - [Hawkpass](https://github.com/kalpetros/hawkpass-desktop) - Password generator.
 - [Gokotta](https://github.com/Zhangdroid/Gokotta) - Music player.
+- [Google Play Music Desktop Player](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-) - Desktop client for Google Play Music (Unofficial).
 
 ### Closed Source
 


### PR DESCRIPTION
Project URL: https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-

Google Play Music Desktop Player (GPMDP) is at its core a desktop wrapper for Google Play Music but it adds a considerable quantity of functionality, including theming support, voice controls, desktop notifications and customizable global hotkeys.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sindresorhus/awesome-electron/202)
<!-- Reviewable:end -->
