### PR TITLE
Add Fog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Some good apps written with Electron.
 - [Shake](https://github.com/lumios/shake) - Japanese Earthquake Early Warning Notifier.
 - [WebTorrent](https://github.com/feross/webtorrent-app) - Streaming torrent client.
 - [Ansel](https://github.com/m0g/ansel) - Image organizer.
+- [Fog](https://github.com/vitorgalvao/fog) - Unofficial overcast.fm podcast app.
 
 ### Closed Source
 


### PR DESCRIPTION
[Homepage](https://github.com/vitorgalvao/fog). Disclaimer: I’m the author.

Fog is an unofficial app for [overcast.fm](https://overcast.fm/). It lets users use it without needing to go to the website, and has some useful extras (such as media keys playback and other shortcuts).