### PR TITLE
Add Wmail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Some good apps written with Electron.
 - [WebTorrent](https://github.com/feross/webtorrent-app) - Streaming torrent client.
 - [Ansel](https://github.com/m0g/ansel) - Image organizer.
 - [Fog](https://github.com/vitorgalvao/fog) - Unofficial Overcast podcast app.
+- [Wmail](https://github.com/Thomas101/wmail) - Unofficial Gmail and Google Inbox app.
 
 ### Closed Source
 


### PR DESCRIPTION
[Homepage](https://github.com/Thomas101/wmail).

Wmail is an unofficial app for Gmail and Google Inbox. It’s under active development, and the developer is very responsive and accommodating to requests.