### PR TITLE
Add 1Clipboard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ Some good apps written with Electron.
 - [Postman](https://www.getpostman.com) - Create and send HTTP requests.
 - [SIV](http://www.integritytools.com/siv/) - Extensible image viewer.
 - [Remember](https://rememberapp.co.kr) - Business card management. *(Korean)*
+- [1Clipboard](http://1clipboard.io/) - A universal clipboard managing app to access your clipboard from anywhere on any device.
 
 
 ## Boilerplates


### PR DESCRIPTION
The evidence of 1Clipboard being built using Electron is found on the [1Clipboard](http://1clipboard.io/) website. Just above the download section on the site.