### PR TITLE
Add electron-input-menu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ Some good apps written with Electron.
 - [Photon](http://photonkit.com) - UI toolkit for building beautiful apps.
 - [React PhotonKit](https://github.com/react-photonkit/react-photonkit) - Photon components built with React.
 - [React Desktop](https://github.com/gabrielbull/react-desktop) - UI toolkit for OS X and Windows built with React.
+- [electron-input-menu](https://github.com/parro-it/electron-input-menu) - Context menu for electron input elements.
 
 
 ## Documentation


### PR DESCRIPTION
https://github.com/parro-it/electron-input-menu

This module add a context menu to all input elements with Copy & Paste item.
Idea come from [this electron issue](https://github.com/atom/electron/issues/4068)