### PR TITLE
Add Before Dawn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@ Some good apps written with Electron.
 - [Fog](https://github.com/vitorgalvao/fog) - Unofficial Overcast podcast app.
 - [Wmail](https://github.com/Thomas101/wmail) - Unofficial Gmail & Google Inbox app.
 - [Boostnote](https://github.com/BoostIO/Boostnote) - Markdown note app for developers.
+- [Before Dawn](https://github.com/muffinista/before-dawn) - Screensaver tool powered by HTML and Javascript.
 
 ### Closed Source
 


### PR DESCRIPTION
Before Dawn is a screensaver tool. The main system is powered by Electron and screensavers can be written in HTML and Javascript. Contributions welcome!

https://github.com/muffinista/before-dawn