### PR TITLE
Add electron-release-server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@ Some good apps written with Electron.
 - [electron-installer-windows](https://github.com/unindented/electron-installer-windows) - Create a Windows package.
 - [electron-json-storage](https://github.com/jviotti/electron-json-storage) - Write and read user settings.
 - [devtool](https://github.com/Jam3/devtool) - Debug Node.js with Chrome DevTools.
+- [electron-release-server](https://github.com/ArekSredzki/electron-release-server) - Self-hosted release server with front-end & auto-updater support.
 
 
 ## Components


### PR DESCRIPTION
By request I've added a link to the `electron-release-server`, a self-hosted release server that makes using the auto-updater much easier.