### PR TITLE
Add podcasts section with list of known episodes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 - [Documentation](#documentation)
 - [Articles](#articles)
 - [Videos](#videos)
+- [Podcasts](#podcasts)
 - [Community](#community)
 - [Tips](#tips)
 
@@ -235,6 +236,9 @@ Some apps made with Electron.
 - [The State of Electron](https://www.youtube.com/watch?v=RaPmi-33rfc)
 - [Cross-Platform Desktop Apps with Electron](https://www.youtube.com/watch?v=Xs3Oc4weZbw)
 
+## Podcasts
+
+- [JavaScript Jabber: Electron with Jessica Lord and Amy Palamountain](https://devchat.tv/js-jabber/193-jsj-electron-with-jessica-lord-and-amy-palamountain)
 
 ## Community
 


### PR DESCRIPTION
This adds a section for podcasts with a list of known episodes featuring Electron. I'm always searching for new podcasts talking about Electron, so it would be great if the community could just periodically check back here instead. :+1: 