### PR TITLE
add electron-stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@ Some apps made with Electron.
 - [devtool](https://github.com/Jam3/devtool) - Debug Node.js with Chrome DevTools.
 - [electron-release-server](https://github.com/ArekSredzki/electron-release-server) - Self-hosted release server with front-end & auto-updater support.
 - [auto-launch](https://github.com/Teamwork/node-auto-launch) - Launch apps at system startup.
+- [electron-stream](https://github.com/juliangruber/electron-stream) - A streaming wrapper.
 
 
 ## Components


### PR DESCRIPTION
https://github.com/juliangruber/electron-stream

This makes it easy to use electron programmatically, like:

```js
var electron = require('electron-stream');

var browser = electron();

browser.pipe(process.stdout);

browser.write('console.log(window.location.href)');
browser.write('window.close();');
browser.end();
```