### PR TITLE
Added pomodoro app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ Some apps made with Electron.
 - [Simplenote](https://github.com/Automattic/simplenote-electron) - Note keeper.
 - [Build Checker App](https://github.com/willmendesneto/build-checker-app) - Check CI-server build statuses.
 - [Min](https://github.com/PalmerAL/Min) - Web browser.
+- [Pomodoro App](https://github.com/veloxy/pomodoro-electron) - Simple pomodoro timer that sits in your menubar.
 
 ### Closed Source
 


### PR DESCRIPTION
I've created a simple [pomodoro app](https://github.com/veloxy/pomodoro-electron) that i would like to share.

It was intended for personal use, but I ended up sharing it with co-workers and friends. I thought i'd submit it here as it might help others creating their app by looking at the code or just using the app and help them be more productive!

It's currently only available on [OSX](https://github.com/veloxy/pomodoro-electron/releases)