### PR TITLE
Add Freeter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@ Made with Electron.
 - [Pubu](https://pubu.im) - Real-time chat for team communication. *(Chinese)*
 - [BearyChat](https://bearychat.com) - Team messaging service. *(Chinese)*
 - [MongoDB Compass](https://www.mongodb.com/products/compass) - Official MongoDB app.
+- [Freeter](https://freeter.io) - The organizer for freelancers & creatives.
 
 
 ## Boilerplates


### PR DESCRIPTION
The evidence of using Electron is on the app screenshot at the top of the website. There is Electron directory within the Freeter project on the file explorer.