### PR TITLE
Add babel-preset-electron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ Made with Electron.
 - [ember-electron](https://github.com/felixrieseberg/ember-electron) - Build, test, and package Ember apps.
 - [electrify](https://github.com/arboleya/electrify) - Package Meteor apps.
 - [spectron](https://github.com/electron/spectron) - Test Electron apps using ChromeDriver.
+- [babel-preset-electron](https://github.com/emorikawa/babel-preset-electron) - A Babel preset that only compiles what's necessary for a particular Electron version.
 
 ### Using Electron
 


### PR DESCRIPTION
The existing babel presets are overkill for Electron. Latest Chromium and
Node support a large majority of ES6 features natively. There's no reason
to compile all `() => {}` calls to babel's bound function indirection.
There's no reason to add a bunch of boilerplate code weight that these
platforms already support.

babel-preset-electron carefully chooses the minimal set of babel plugins
necessary to support ES6 and stage-0 and up.

The version of the repo tracks the Electron version that it has been
tested on.

This has been battle-tested in [Nylas N1](https://github.com/nylas/n1) for
the latest Electron versions. As more Electron versions come out,
babel-preset-electron will continue to be tagged.