### PR TITLE
Added is-electron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ Made with Electron.
 - [ember-electron](https://github.com/felixrieseberg/ember-electron) - Build, test, and package Ember apps.
 - [electrify](https://github.com/arboleya/electrify) - Package Meteor apps.
 - [spectron](https://github.com/electron/spectron) - Test Electron apps using ChromeDriver.
+- [is-electron](https://github.com/delvedor/is-electron) - An 'is' utility which provides a set of handy functions, with a self-descriptive name.
 
 ### Using Electron
 


### PR DESCRIPTION
*Added 'is-electron' library under 'Tools' section.*
_______________________________________________________________________
**Description:**
An 'is' utility for Electron.
[is-electron](https://github.com/delvedor/is-electron) provides a set of isomorphic 'is' APIs, that you can use it both in main and renderer process.

**Why it should be included:**
I think it can be a useful tool, it's pretty handy and makes the code easier to read.

*Ps: I hope you find it useful, I'm open to suggestions and improvements!*