### PR TITLE
Add electron-is

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ Made with Electron.
 - [electrify](https://github.com/arboleya/electrify) - Package Meteor apps.
 - [spectron](https://github.com/electron/spectron) - Test Electron apps using ChromeDriver.
 - [babel-preset-electron](https://github.com/emorikawa/babel-preset-electron) - Babel preset that only compiles what's necessary for a particular Electron version.
+- [electron-is](https://github.com/delvedor/electron-is) - An 'is' utility which provides a set of handy functions, with a self-descriptive name.
 
 ### Using Electron
 


### PR DESCRIPTION
*Added 'electron-is' library under 'Tools' section.*
_______________________________________________________________________
**Description:**
An 'is' utility for Electron.
[electron-is](https://github.com/delvedor/electron-is) provides a set of isomorphic 'is' APIs, that you can use it both in main and renderer process.

**Why it should be included:**
I think it can be a useful tool, it's pretty handy and makes the code easier to read.

*Ps: I hope you find it useful, I'm open to suggestions and improvements!*