### PR TITLE
Add osx-appearance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,7 @@ Made with Electron.
 - [spectron](https://github.com/electron/spectron) - Test Electron apps using ChromeDriver.
 - [babel-preset-electron](https://github.com/emorikawa/babel-preset-electron) - Babel preset that only compiles what's necessary for a particular Electron version.
 - [electron-is](https://github.com/delvedor/electron-is) - Useful 'is' utility functions.
+- [electron-osx-appearance](https://github.com/danhp/electron-osx-appearance) - Simplified API for accessing OS X's appearance settings.
 
 ### Using Electron
 


### PR DESCRIPTION
https://github.com/danhp/electron-osx-appearance

I think it's time I add this guy to the list since we've been using of it in Caprine for little while now.