### PR TITLE
Add bozon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Made with Electron.
 - [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) *(by szwacz)* - Comprehensive boilerplate which even generates installers.
 - [electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate) - Boilerplate based on React and webpack.
 - [descjop](https://github.com/karad/lein_template_descjop) - ClojureScript boilerplate for creating an app.
+- [bozon](https://github.com/railsware/bozon) - Simple tool for scaffolding, running, testing, and packaging your application.
 
 
 ## Tools


### PR DESCRIPTION
[Bozon](https://github.com/railsware/bozon) is a single tool for handling different tasks being performed by multiple packages. Makes it easier to scaffold, run, test, and package Electron applications.