### PR TITLE
Add Electronic WeChat.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Made with Electron.
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Cross-platform IDE.
 - [N1](https://github.com/nylas/N1) - Extensible email client.
 - [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
+- [Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) - A better WeChat on Mac OS X and Linux.
 
 ###### Other
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,6 @@ Made with Electron.
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Cross-platform IDE.
 - [N1](https://github.com/nylas/N1) - Extensible email client.
 - [Brave](https://github.com/brave/browser-laptop) - Privacy-focused web browser.
-- [Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) - A better WeChat on Mac OS X and Linux.
 
 ###### Other
 
@@ -135,6 +134,7 @@ Made with Electron.
 - [Whatsie](https://github.com/Aluxian/Whatsie) - Unofficial WhatsApp app.
 - [PupaFM](https://github.com/xwartz/PupaFM) - DoubanFM music player.
 - [MediumDesk](https://github.com/sivragav/mediumdesk) - Unofficial Medium app.
+- [Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) - A better WeChat on Mac OS X and Linux.
 
 ### Closed Source
 


### PR DESCRIPTION
[WeChat](https://en.wikipedia.org/wiki/WeChat) is one of the largest standalone messaging apps, with 700 million active users.

[Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) is a third party app, providing a better WeChat on Mac OS X and Linux, with fewer bugs and more features. 

It has been used by many, with 3000+ stars on GitHub.