### PR TITLE
Add Electron in Action

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -260,6 +260,9 @@ Made with Electron.
 - [Codesigning your app for OS X](http://jbavari.github.io/blog/2015/08/14/codesigning-electron-applications/)
 - [Auto-updating apps for Windows and OS X: The complete guide](https://medium.com/@svilen/auto-updating-apps-for-windows-and-osx-using-electron-the-complete-guide-4aa7a50b904c)
 
+## Books
+
+- [Electron in Action](https://www.manning.com/books/electron-in-action) - Manning Early Access Program (MEAP), estimated publication in summer of 2017.
 
 ## Videos
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nod
 - [Components](#components)
 - [Documentation](#documentation)
 - [Articles](#articles)
+- [Books](#books)
 - [Videos](#videos)
 - [Podcasts](#podcasts)
 - [Community](#community)


### PR DESCRIPTION
[Electron in Action](https://www.manning.com/books/electron-in-action) is a Manning book that is currently available for purchase and download of the completed portions under the MEAP program. Currently 2 out of 20 chapters are completed. All future updates to the book are included in the purchase. Estimated publication date is summer 2017.