### PR TITLE
Add electron-devtools-installer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,7 @@ Made with Electron.
 - [electron-context-menu](https://github.com/sindresorhus/electron-context-menu) - Extensible context menu.
 - [electron-require](https://github.com/brrd/electron-require) - Simplified require.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in memory database.
+- [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Easily install DevTools extensions from the Chrome WebStore into Electron
 
 ### Using Electron
 


### PR DESCRIPTION
Useful tool for installing DevTools extensions directly from the Chrome WebStore