### PR TITLE
Add iStats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ Made with Electron.
 - [Marky](https://github.com/vesparny/marky) - Markdown editor.
 - [Deco](https://github.com/decosoftware/deco-ide) - React Native IDE.
 - [Toshocat](https://github.com/tofuness/Toshocat) - Anime/Manga Progress Tracker.
+- [iStats](https://github.com/ningt/iStats) - Display cpu and memory stats on your Mac menubar.
 
 ### Closed Source
 


### PR DESCRIPTION
iStats (display cpu and memory info on your Mac menubar)