### PR TITLE
Add sudo-prompt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ Made with Electron.
 - [electron-require](https://github.com/brrd/electron-require) - Simplified require.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in memory database.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
+- [sudo-prompt](https://github.com/jorangreef/sudo-prompt) - Cross-platform `sudo`, prompting the user with a graphical OS dialog if necessary.
 
 ### Using Electron
 


### PR DESCRIPTION
Cross-platform `sudo`, prompting the user with a graphical OS dialog if necessary.