### PR TITLE
Add electron-log

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ Made with Electron.
 - [electron-require](https://github.com/brrd/electron-require) - Simplified require.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in memory database.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
+- [electron-log](https://github.com/megahertz/electron-log) - Very simple logging module.
 
 ### Using Electron
 


### PR DESCRIPTION
This is a very simple logging module for Electron application. It has no dependencies and can be used without configuration. By default it writes log files to the same folder which is used by electron (except for osx):
 * **on Linux:** `~/.config/<app name>/log.log`
 * **on OS X:** `~/Library/Logs/<app name>/log.log`
 * **on Windows:** `$HOME/AppData/Roaming/<app name>/log.log`