### PR TITLE
adding Electrello and fASCI to open src apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,8 @@ Made with Electron.
 - [Toshocat](https://github.com/tofuness/Toshocat) - Anime/Manga Progress Tracker.
 - [iStats](https://github.com/ningt/iStats) - CPU and memory stats on your menubar.
 - [Wire](https://github.com/wireapp/wire-desktop) - Messenger and calling app.
+- [Electrello](https://github.com/Banjerr/electrello) - Trello experience for the desktop
+- [fASCII](https://github.com/Banjerr/fASCII) - Menubar app to pair your current mood to the perfect ASCII faces (actually they're unicode)
 
 ### Closed Source
 


### PR DESCRIPTION
Electrello is a Trello desktop app, still being developed

fASCII is a menubar app that pairs your mood with a cool face, version 1 released