### PR TITLE
Add Dext

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Made with Electron.
 - [Toshocat](https://github.com/tofuness/Toshocat) - Anime/Manga Progress Tracker.
 - [iStats](https://github.com/ningt/iStats) - CPU and memory stats on your menubar.
 - [Wire](https://github.com/wireapp/wire-desktop) - Messenger and calling app.
+- [Dext](https://github.com/vutran/dext) - A smart launcher for Mac. Powered by JavaScript.
 
 ### Closed Source
 


### PR DESCRIPTION
Mac launcher app aimed to be compatible with existing Alfred workflows. Eventually looking to support Python workflows and Alfred themes as well.