### PR TITLE
Add electron-redux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,7 @@ Made with Electron.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in memory database.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
 - [electron-log](https://github.com/megahertz/electron-log) - Simple logging.
+- [electron-redux](https://github.com/hardchor/electron-redux) - Powerful tools to use redux with Electron.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -245,7 +245,7 @@ Made with Electron.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in memory database.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
 - [electron-log](https://github.com/megahertz/electron-log) - Simple logging.
-- [electron-redux](https://github.com/hardchor/electron-redux) - Powerful tools to use redux with Electron.
+- [electron-redux](https://github.com/hardchor/electron-redux) - Synchronise redux-state across windows.
 
 ### Using Electron
 


### PR DESCRIPTION
https://github.com/hardchor/electron-redux provides a way to synchronise state across windows and handle actions on both main- and renderer processes.

The issue of using redux in Electron has come up several times, e.g. in https://github.com/chentsulin/electron-react-boilerplate/issues/108#issuecomment-239665178
