### PR TITLE
Remove duplicate link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -299,14 +299,13 @@ Made with Electron.
 
 ## Videos
 
-- [Creating Desktop Apps with Electron](https://www.youtube.com/watch?v=jKzBJAowmGg)
+- [Getting Started with Electron 1.x](https://www.youtube.com/watch?v=jKzBJAowmGg)
 - [Packaging and Distributing Electron Desktop Apps](https://www.youtube.com/watch?v=dz5SnmBzBXc)
 - [Multi Window Electron Desktop Apps](https://www.youtube.com/watch?v=K-H2amwQ_pU)
 - [The State of Electron](https://www.youtube.com/watch?v=RaPmi-33rfc)
 - [Cross-Platform Desktop Apps with Electron](https://www.youtube.com/watch?v=9xX_G0l5jLU)
 - [Building Native Desktop apps using Electron](https://www.youtube.com/watch?v=nXIrFq5-FC8)
 - [The New Desktop: Electron, React, & Pixel-Perfect Native-Feeling Experiences](https://www.youtube.com/watch?v=jRPUB-D1Wx0)
-- [Getting Started with Electron 1.x](https://www.youtube.com/watch?v=jKzBJAowmGg)
 - [Building Desktop Apps with Node.js and Electron](https://www.youtube.com/watch?v=rbSvc8_BHaw)
 - [Electron Fundamentals course - Pluralsight](https://www.pluralsight.com/courses/electron-fundamentals) 💲
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Turns out the old video and the new one were both in the list. So where my previous pull replaced the deprecated video this one removes the duplicate and moves the other "quick start" video to the top of the list.