### PR TITLE
Add Brightwheel to Components section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -278,6 +278,7 @@ Made with Electron.
 - [electron-input-menu](https://github.com/parro-it/electron-input-menu) - Context menu for input elements.
 - [chrome-tabs](https://github.com/adamschwartz/chrome-tabs) - Chrome like tabs.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the macOS window titlebar.
+- [Brightwheel](https://github.com/loranallensmith/brightwheel) - Build and manage UI components with Photon and Etch.
 
 
 ## Documentation


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

This Pull Request adds a link to [Brightwheel](https://github.com/loranallensmith/brightwheel) (https://github.com/loranallensmith/brightwheel), a library that lets you build and manage Photon UI components with JavaScript.

It's similar to [React PhotonKit](https://github.com/react-photonkit/react-photonkit), but it relies on [Etch](https://github.com/atom/etch) for component management instead.
