### PR TITLE
Add electron-about-window

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,7 @@ Made with Electron.
 - [electron-log](https://github.com/megahertz/electron-log) - Simple logging.
 - [electron-redux](https://github.com/hardchor/electron-redux) - Synchronize Redux state across windows.
 - [electron-vibrancy](https://github.com/arkenthera/electron-vibrancy) - Add vibrancy (blur) to windows.
+- [electron-about-window](https://github.com/rhysd/electron-about-window) - 'About This App' window.
 
 ### Using Electron
 


### PR DESCRIPTION
I created [electron-about-window](https://github.com/rhysd/electron-about-window) to provide one-stop 'About This App' window. I introduced it on some applications and it works well cross platform 😄 