### PR TITLE
Add electron-pdf-window to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,7 @@ Made with Electron.
 - [electron-about-window](https://github.com/rhysd/electron-about-window) - 'About This App' window.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
+- [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
 
 ### Using Electron
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

This PR adds [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) to the tools for Electron list.

This module let's you simply add PDF viewing support to browser windows with [pdf.js](https://github.com/mozilla/pdf.js).