### PR TITLE
Add Electro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ Made with Electron.
 - [Extraterm](https://github.com/sedwards2009/extraterm) - Terminal.
 - [Materialette](https://github.com/mike-schultz/materialette) - Material design color palette in your menubar.
 - [Dext](https://github.com/vutran/dext) - Launcher.
+- [Electro](https://github.com/jspear29/electro) - DJ songs from YouTube.
 
 ### Closed Source
 


### PR DESCRIPTION
I've been working this app off and on for about 8 months now.  It's a DJ app that downloads song from YouTube and uses the WebAudio API to change things like pitch, eq and gain.  It also uses Web RTC features in chromium to let the user choose which audio output to send sound to (cue vs. master).  I would love for it to be included in the list.  

Repo:
https://github.com/jspear29/electro

Latest binary:
https://github.com/jspear29/electro/releases/tag/v0.0.6-alpha

Project Site:
https://jspear29.github.io/electro/
