### PR TITLE
Add PB for Desktop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ Made with Electron.
 - [Extraterm](https://github.com/sedwards2009/extraterm) - Terminal.
 - [Materialette](https://github.com/mike-schultz/materialette) - Material design color palette in your menubar.
 - [Dext](https://github.com/vutran/dext) - Launcher.
+- [PB for Desktop](https://github.com/sidneys/pb-for-desktop) - PushBullet desktop app for macOS, Windows and Linux.
 
 ### Closed Source
 


### PR DESCRIPTION
Added PB for Desktop, the open source Pushbullet desktop client app.

Reason: It should be included as its somewhat mature, already has a small user base and would benefit from additional contributors.

Link: https://github.com/sidneys/pb-for-desktop
