### PR TITLE
Add electron-in-page-search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,6 +261,7 @@ Made with Electron.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
+- [electron-in-page-search](https://github.com/rhysd/electron-in-page-search) - Native in-page search like Chrome.
 
 ### Using Electron
 


### PR DESCRIPTION
#**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

I created [this module](https://github.com/rhysd/electron-in-page-search) for in-page search API of `WebContents` (or `<webview>`) instance. Electron's original in-page search APIs are stateful and have some pitfalls. This package wraps them and hide complexity of APIs behind.

It's tested in all platforms using Travis CI and Appveyor. I already used this package in [my app](https://github.com/rhysd/Chromenu) and it works well.

![](https://raw.githubusercontent.com/rhysd/ss/master/electron-in-page-search/main.gif)

