### PR TITLE
Add several tools for electron 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,6 +265,10 @@ Made with Electron.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
+- [electron-ipc-listener](https://github.com/electron-utils/electron-ipc-listener) - IPC listener which will cache the callbacks for easily clear.
+- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Improved IPC APIs.
+- [electron-platform](https://github.com/electron-utils/electron-platform) - Platform detection.
+- [electron-quick-inspect](https://github.com/electron-utils/electron-quick-inspect) - Quickly inspect an element at mouse position.
 
 ### Using Electron
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

 - I created [electron-ipc-listener](https://github.com/electron-utils/electron-ipc-listener) to make it easy to remove ipc listeners for specific group.
 - I created [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) to make Electron ipc module can wait for callback reply from remote process.
 - I created [electron-platform](https://github.com/electron-utils/electron-platform) to help user use same API to detect platform (and main/renderer process) in Electorn, web browser and node.js.
 - I created [electron-quick-inspect](https://github.com/electron-utils/electron-quick-inspect) to let user easily inspect elements in Electron without opening devtools.