### PR TITLE
Add electron-ipc-plus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ Made with Electron.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
-- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Allow IPC handler wait for the reply from sender.
+- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Allow IPC handler wait for the reply from receiver.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ Made with Electron.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
-- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Allow IPC handler wait for the reply from receiver.
+- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Allow IPC sender wait for the reply from receiver.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -265,6 +265,7 @@ Made with Electron.
 - [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
+- [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus) - Allow IPC handler wait for the reply from sender.
 
 ### Using Electron
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Add the [electron-ipc-plus](https://github.com/electron-utils/electron-ipc-plus), this module improved the Electron's ipcMain and ipcRenderer module, it allows user wait for the reply when sending an IPC message in both process.