### PR TITLE
Update elemon link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -263,7 +263,7 @@ Made with Electron.
 - [electron-redux](https://github.com/hardchor/electron-redux) - Synchronize Redux state across windows.
 - [electron-vibrancy](https://github.com/arkenthera/electron-vibrancy) - Add vibrancy (blur) to windows.
 - [electron-about-window](https://github.com/rhysd/electron-about-window) - 'About This App' window.
-- [elemon](https://github.com/mawni/elemon) - Live-reload your app during development.
+- [elemon](https://github.com/manidlou/elemon) - Live-reload your app during development.
 - [electron-is-accelerator](https://github.com/brrd/electron-is-accelerator) - Check if a string is a valid accelerator.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
 - [electron-router](https://github.com/m0n0l0c0/electron-router) - Router tidying up IPC message passing.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

This PR updates `elemon` link in readme. I changed my username from `mawni` to `manidlou`, So I updated the `elemon` link to the new repo.

- old repo: https://github.com/mawni/elemon

- new repo: https://github.com/manidlou/elemon

Sorry for inconvenience. Thanks a lot.