### PR TITLE
Add Desktop Dimmer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Made with Electron.
 - [Zazu](https://github.com/tinytacoteam/zazu) - Launcher.
 - [Inpad](https://github.com/sarah-seo/Inpad) - Notes app with GitHub-flavored Markdown.
 - [Cerebro](https://github.com/KELiON/cerebro) - Launcher with inline previews.
+- [Desktop Dimmer](https://github.com/sidneys/desktop-dimmer) - Control the brightness of any display.
 
 ### Closed Source
 


### PR DESCRIPTION
Added Desktop Dimmer, an open-source approach for controlling desktop brightness.

Reason:
It's been out there for a while ('soft-launched') and has so far proven to be of assistance to its small developer-heavy user base. Additional exposure would improve roadmaps' feature prioritization.

Link:
https://github.com/sidneys/desktop-dimmer
