### PR TITLE
Rename `Sync` to `Wantedly Chat`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ Made with Electron.
 - [Caret](http://caret.io) - Markdown editor.
 - [Wagon](https://www.wagonhq.com) - SQL editor.
 - [SIV](http://www.integritytools.com/siv/) - Image viewer.
-- [Wantedly Chat](https://www.wantedly.com/chat) - Business chat tool that will boost productivity for your team. *(Japanese)*
+- [Wantedly Chat](https://www.wantedly.com/chat) - Business team chat. *(Japanese)*
 - [Remember](https://rememberapp.co.kr) - Business card management. *(Korean)*
 - [Pubu](https://pubu.im) - Real-time chat for team communication. *(Chinese)*
 - [BearyChat](https://bearychat.com) - Team messaging service. *(Chinese)*

--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ Made with Electron.
 - [Caret](http://caret.io) - Markdown editor.
 - [Wagon](https://www.wagonhq.com) - SQL editor.
 - [SIV](http://www.integritytools.com/siv/) - Image viewer.
-- [Sync](https://www.wantedly.com/sync) - Team group messaging. *(Japanese)*
+- [Wantedly Chat](https://www.wantedly.com/chat) - Business chat tool that will boost productivity for your team. *(Japanese)*
 - [Remember](https://rememberapp.co.kr) - Business card management. *(Korean)*
 - [Pubu](https://pubu.im) - Real-time chat for team communication. *(Chinese)*
 - [BearyChat](https://bearychat.com) - Team messaging service. *(Chinese)*


### PR DESCRIPTION
Hi, we asked you to list our app (Sync) in this repository before. But now Sync is renamed Wantedly Chat.
You can download from https://www.wantedly.com/chat

Cc. @luvtechno 
Past pull request. https://github.com/sindresorhus/awesome-electron/pull/135

> Additions should be added to the bottom of the relevant section

If we have to add to the bottom, I'll fix it.