### PR TITLE
Add electron-settings to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -279,6 +279,7 @@ Made with Electron.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - View PDF files in browser windows.
 - [electron-router](https://github.com/m0n0l0c0/electron-router) - Router tidying up IPC message passing.
 - [electron-lets-move](https://github.com/tommoor/electron-lets-move) - Automatically move your app to `/Applications` on macOS.
+- [electron-settings](https://github.com/nathanbuchar/electron-settings) - Reads and writes user settings to disk.
 
 ### Using Electron
 


### PR DESCRIPTION
[electron-settings](https://github.com/nathanbuchar/electron-settings) is a simple persistent user settings manager, originally adapted from Atom's own internal configuration manager. It was also just recently adopted as the settings manager of choice for Github's [demo Electron app](https://github.com/electron/electron-api-demos).

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
