### PR TITLE
Add Xel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -306,6 +306,7 @@ Made with Electron.
 - [chrome-tabs](https://github.com/adamschwartz/chrome-tabs) - Chrome like tabs.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the macOS window titlebar.
 - [Brightwheel](https://github.com/loranallensmith/brightwheel) - Build and manage UI components with Photon and Etch.
+- [Xel](https://xel-toolkit.org/) - Widget toolkit for building native-like apps.
 
 
 ## Documentation

--- a/readme.md
+++ b/readme.md
@@ -306,7 +306,7 @@ Made with Electron.
 - [chrome-tabs](https://github.com/adamschwartz/chrome-tabs) - Chrome like tabs.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the macOS window titlebar.
 - [Brightwheel](https://github.com/loranallensmith/brightwheel) - Build and manage UI components with Photon and Etch.
-- [Xel](https://xel-toolkit.org/) - Widget toolkit for building native-like apps.
+- [Xel](https://xel-toolkit.org) - Widget toolkit for building native-like apps.
 
 
 ## Documentation


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

https://xel-toolkit.org/
https://github.com/jarek-foksa/xel

Xel is a widget toolkit for building native-like Electron apps. Currently it supports Material and macOS themes, with more coming soon.

The project was in development in a private repo for several months, though I made it public just few days ago (not sure if this falls under the 20 days limit).