### PR TITLE
Add a video: Automatically Build and Publish Node and Electron Applications for Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,7 @@ Made with Electron.
 - [Building Desktop Apps with Node.js and Electron](https://www.youtube.com/watch?v=rbSvc8_BHaw)
 - [Electron Fundamentals course - Pluralsight](https://www.pluralsight.com/courses/electron-fundamentals) 💲
 - [Electron: Building Cross Platform Desktop Apps - Lynda](https://www.lynda.com/Electron-tutorials/Electron-Building-Cross-Platform-Desktop-Apps/518051-2.html) 💲
+- [Automatically Build and Publish Node and Electron Applications for Linux](https://pusher.com/sessions/meetup/london-node-user-group/automatically-build-and-publish-node-and-electron-applications-for-linux)
 
 
 ## Podcasts


### PR DESCRIPTION
I gave a talk a few weeks ago about automatically building and publishing Node.JS and Electron applications for Linux using Snapcraft. Of particular interest to Electron developers is that `electron-builder` has first class support for snaps and publishing in the snap store gives feature parity with the built-in auto-update features available in Electron for Windows and macOS. Snaps of Electron applications published in the store will be discoverable via the Software store installed by default in all major Linux distributions.

This pull request adds the video of that talk.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
