### PR TITLE
Add Egghead course

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -350,6 +350,7 @@ Made with Electron.
 - [Automatically Build and Publish Node and Electron Applications for Linux](https://pusher.com/sessions/meetup/london-node-user-group/automatically-build-and-publish-node-and-electron-applications-for-linux)
 - [Build a desktop application with Electron - Egghead](https://egghead.io/courses/build-a-desktop-application-with-electron) 💲
 
+
 ## Podcasts
 
 - [JavaScript Jabber: Electron with Jessica Lord and Amy Palamountain](https://devchat.tv/js-jabber/193-jsj-electron-with-jessica-lord-and-amy-palamountain)

--- a/readme.md
+++ b/readme.md
@@ -348,7 +348,7 @@ Made with Electron.
 - [Electron Fundamentals course - Pluralsight](https://www.pluralsight.com/courses/electron-fundamentals) 💲
 - [Electron: Building Cross Platform Desktop Apps - Lynda](https://www.lynda.com/Electron-tutorials/Electron-Building-Cross-Platform-Desktop-Apps/518051-2.html) 💲
 - [Automatically Build and Publish Node and Electron Applications for Linux](https://pusher.com/sessions/meetup/london-node-user-group/automatically-build-and-publish-node-and-electron-applications-for-linux)
-- [Build a desktop application with Electron - Egghead](https://egghead.io/courses/build-a-desktop-application-with-electron)
+- [Build a desktop application with Electron - Egghead](https://egghead.io/courses/build-a-desktop-application-with-electron) 💲
 
 ## Podcasts
 

--- a/readme.md
+++ b/readme.md
@@ -348,7 +348,7 @@ Made with Electron.
 - [Electron Fundamentals course - Pluralsight](https://www.pluralsight.com/courses/electron-fundamentals) 💲
 - [Electron: Building Cross Platform Desktop Apps - Lynda](https://www.lynda.com/Electron-tutorials/Electron-Building-Cross-Platform-Desktop-Apps/518051-2.html) 💲
 - [Automatically Build and Publish Node and Electron Applications for Linux](https://pusher.com/sessions/meetup/london-node-user-group/automatically-build-and-publish-node-and-electron-applications-for-linux)
-
+- [Build a desktop application with Electron - Egghead](https://egghead.io/courses/build-a-desktop-application-with-electron)
 
 ## Podcasts
 


### PR DESCRIPTION
I created a video course that walks you through creating and deploying an Electron app from start to finish. 

Egghead requires you to have a subscription to view all of the videos, but Egghead also allows non-subscribers to view at least a few of the videos. So I wasn't sure on whether to add that little dollar sign. I can add that in if desired. 

The course is here:
https://egghead.io/courses/build-a-desktop-application-with-electron