### PR TITLE
Add article

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Made with Electron.
 - [Inpad](https://github.com/sarah-seo/Inpad) - Notes app with GitHub-flavored Markdown.
 - [Cerebro](https://github.com/KELiON/cerebro) - Launcher with inline previews.
 - [Desktop Dimmer](https://github.com/sidneys/desktop-dimmer) - Control the brightness of any display.
+- [LosslessCut](https://github.com/mifi/lossless-cut) - Lossless video trimming & cutting.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -322,7 +322,7 @@ Made with Electron.
 - [Auto-updating apps for macOS and Windows: The complete guide](https://medium.com/@svilen/auto-updating-apps-for-windows-and-osx-using-electron-the-complete-guide-4aa7a50b904c)
 - [How To Make Your Electron App Sexy](https://blog.dcpos.ch/how-to-make-your-electron-app-sexy)
 - [Electron Rocks!](http://electron.rocks) - Blog about working with Electron.
-- [Building desktop applications with Electron](https://anadea.info/blog/building-desktop-app-with-electron) 
+- [Building a desktop app with Electron, React, and Redux](https://anadea.info/blog/building-desktop-app-with-electron) 
 
 
 ## Books


### PR DESCRIPTION
I Added an entry to the Articles section that points to andea.info blog post tutorial on building desktop applications with electron