### PR TITLE
Add `ipc-flux`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ Made with Electron.
 - [got](https://github.com/sindresorhus/got) - Simplified HTTP requests.
 - [electron-unhandled](https://github.com/sindresorhus/electron-unhandled) - Catch unhandled errors and promise rejections.
 - [electron-process-manager](https://github.com/getstation/electron-process-manager) - Process manager UI (like Chrome's task manager).
-- [ipc-flux](https://github.com/harryparkdotio/ipc-flux) - Flux like state & action management across processes (ipc).
+- [ipc-flux](https://github.com/harryparkdotio/ipc-flux) - Flux-like state and action management across processes (IPC).
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,7 @@ Made with Electron.
 - [got](https://github.com/sindresorhus/got) - Simplified HTTP requests.
 - [electron-unhandled](https://github.com/sindresorhus/electron-unhandled) - Catch unhandled errors and promise rejections.
 - [electron-process-manager](https://github.com/getstation/electron-process-manager) - Process manager UI (like Chrome's task manager).
+- [ipc-flux](https://github.com/harryparkdotio/ipc-flux) - Flux like state & action management across processes (ipc).
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ Made with Electron.
 - [got](https://github.com/sindresorhus/got) - Simplified HTTP requests.
 - [electron-unhandled](https://github.com/sindresorhus/electron-unhandled) - Catch unhandled errors and promise rejections.
 - [electron-process-manager](https://github.com/getstation/electron-process-manager) - Process manager UI (like Chrome's task manager).
-- [ipc-flux](https://github.com/harryparkdotio/ipc-flux) - Flux-like state and action management across processes (IPC).
+- [ipc-flux](https://github.com/harryparkdotio/ipc-flux) - Flux-like state and action management across processes.
 
 ### Using Electron
 


### PR DESCRIPTION
allows for action dispatching (flux) between main & renderer processes

[ipc-flux](https://github.com/harryparkdotio/ipc-flux)

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

> P.S.&nbsp;&nbsp;Sorry for the new pull request, I wasn't able to edit the old one