### PR TITLE
Add `typescript-react-boilerplate`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,7 @@ Made with Electron.
 - [electron-quick-start](https://github.com/electron/electron-quick-start) - Clone the repo to try a simple app.
 - [bozon](https://github.com/railsware/bozon) - Scaffold, run, test, and package your app.
 - [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
+- [typescript-react-boilerplate](https://github.com/lieone/typescript-react-boilerplate) - Main and renderer both in TypeScript
 
 
 ## Tools


### PR DESCRIPTION
Inspired by [Announcing TypeScript support in Electron](https://electron.atom.io/blog/2017/06/01/typescript). Created from regular TS web app example for React. Main and renderer both process in pure TypeScript. Link to repo [typescript-react-boilerplate](https://github.com/lieone/typescript-react-boilerplate).

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
