### PR TITLE
Add WAIL to list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Made with Electron.
 - [Wexond](https://github.com/sential/wexond) - Web browser with material UI and extensions API.
 - [Buka](https://github.com/oguzhaninan/Buka) - E-book management.
 - [Insomnia](https://github.com/getinsomnia/insomnia) - Create and manage HTTP requests.
+- [WAIL](https://github.com/N0taN3rd/wail) - Collection based personal web archiving.
 
 ### Closed Source
 
@@ -329,7 +330,7 @@ Made with Electron.
 - [Auto-updating apps for macOS and Windows: The complete guide](https://medium.com/@svilen/auto-updating-apps-for-windows-and-osx-using-electron-the-complete-guide-4aa7a50b904c)
 - [How To Make Your Electron App Sexy](https://blog.dcpos.ch/how-to-make-your-electron-app-sexy)
 - [Electron Rocks!](http://electron.rocks) - Blog about working with Electron.
-- [Building a desktop app with Electron, React, and Redux](https://anadea.info/blog/building-desktop-app-with-electron) 
+- [Building a desktop app with Electron, React, and Redux](https://anadea.info/blog/building-desktop-app-with-electron)
 
 
 ## Books


### PR DESCRIPTION
This PR adds [WAIL](https://github.com/N0taN3rd/wail) (Web Archiving Integration Layer) a tool intended to be used as an easy way for anyone to build collections of web archives and to preserve and replay web pages from their personal computers.

For more information about WAIL see the projects [wiki](https://github.com/N0taN3rd/wail/wiki) or the [Web Science and Digital Libraries Research Group](https://github.com/oduwsdl) blog post introducing [WAIL 1.0](http://ws-dl.blogspot.com/2017/02/2017-02-13-electric-wails-and-ham.html). 

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
