### PR TITLE
Add unofficial ProtonMail Desktop app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,8 +170,9 @@ Made with Electron.
 - [Buka](https://github.com/oguzhaninan/Buka) - E-book management.
 - [Insomnia](https://github.com/getinsomnia/insomnia) - Create and manage HTTP requests.
 - [Tusk](https://github.com/champloohq/tusk) - Unofficial Evernote app.
-- [ProtonMail Desktop](https://github.com/protonmail-desktop/application) - Unofficial ProtonMail Desktop app with support for multiple accounts.
- 
+- [ProtonMail Desktop](https://github.com/protonmail-desktop/application) - Unofficial ProtonMail app.
+
+
 ### Closed Source
 
 - [GitKraken](http://www.gitkraken.com) - Git client.

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,6 @@ Made with Electron.
 - [Tusk](https://github.com/champloohq/tusk) - Unofficial Evernote app.
 - [ProtonMail Desktop](https://github.com/protonmail-desktop/application) - Unofficial ProtonMail app.
 
-
 ### Closed Source
 
 - [GitKraken](http://www.gitkraken.com) - Git client.

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,8 @@ Made with Electron.
 - [Buka](https://github.com/oguzhaninan/Buka) - E-book management.
 - [Insomnia](https://github.com/getinsomnia/insomnia) - Create and manage HTTP requests.
 - [Tusk](https://github.com/champloohq/tusk) - Unofficial Evernote app.
-
+- [ProtonMail Desktop](https://github.com/protonmail-desktop/application) - Unofficial ProtonMail Desktop app with support for multiple accounts.
+ 
 ### Closed Source
 
 - [GitKraken](http://www.gitkraken.com) - Git client.


### PR DESCRIPTION
https://github.com/protonmail-desktop/application is an unofficial ProtonMail wrapper with support for multiple accounts in one window. We're planning to add more features later on. Feature proposals and feedback are welcome. 

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
