### PR TITLE
Add Buttercup Desktop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,7 @@ Made with Electron.
 - [Tusk](https://github.com/champloohq/tusk) - Unofficial Evernote app.
 - [ProtonMail Desktop](https://github.com/protonmail-desktop/application) - Unofficial ProtonMail app.
 - [Comma Chameleon](https://github.com/theodi/comma-chameleon) - CSV editor.
+- [Buttercup Desktop](https://github.com/buttercup/buttercup-desktop) - Password manager.
 
 ### Closed Source
 


### PR DESCRIPTION
Buttercup (Desktop) is an open source password manager built on Electron. It's been in the wild for almost 2 years now, available on Mac, Linux and Windows.

Website: [buttercup.pw](https://buttercup.pw)

<img width="1115" alt="screen shot 2017-05-19 at 13 51 30" src="https://user-images.githubusercontent.com/3869469/32930832-b6e72852-cb69-11e7-8f6c-c528cbe7acb1.png">
