### PR TITLE
Update electron.atom.io -> electronjs.org

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -10,7 +10,7 @@ Ensure your pull request adheres to the following guidelines:
 - If you just created something, wait at least 30 days before submitting.
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - If you're submitting a closed source app, include evidence of it being built with Electron.
-- The "Closed Source" section has a very high bar for acceptance. You're at lot more likely to get accepted if you link to a blog post on how you built the app. Don't worry if your submission is declined, you can still submit your app to the [official Electron apps list](http://electron.atom.io/apps/).
+- The "Closed Source" section has a very high bar for acceptance. You're at lot more likely to get accepted if you link to a blog post on how you built the app. Don't worry if your submission is declined, you can still submit your app to the [official Electron apps list](https://electronjs.org/apps).
 - Submitted open source apps should have a English readme, screenshot of the app in the readme, and a binary for at least one OS, preferably macOS, Linux and Windows.
 - Submitted packages should be tested and documented.
 - Make an individual pull request for each suggestion.

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Awesome Electron [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-[<img src="https://rawgit.com/sindresorhus/awesome-electron/master/electron-logo.svg" align="right" width="100">](http://electron.atom.io)
+[<img src="https://rawgit.com/sindresorhus/awesome-electron/master/electron-logo.svg" align="right" width="100">](https://electronjs.org)
 
-> Useful resources for creating apps with [Electron](http://electron.atom.io)
+> Useful resources for creating apps with [Electron](https://electronjs.org)
 
 You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nodejs).
 
@@ -217,9 +217,9 @@ Made with Electron.
 
 - [Electron API usage](https://github.com/hokein/electron-sample-apps) - Sample apps illustrating usage of Electron APIs.
 - [Screen Recorder](https://github.com/hokein/electron-screen-recorder) - WebRTC screen recorder.
-- [Activity Monitor](http://electron.atom.io/blog/2017/01/19/simple-samples#activity-monitor) - Shows a doughnut chart of the CPU system, user, and idle activity time.
-- [Hash](http://electron.atom.io/blog/2017/01/19/simple-samples#hash) - Shows the hash values of entered text using different algorithms.
-- [Prices](http://electron.atom.io/blog/2017/01/19/simple-samples#prices) - Shows the current price of oil, gold, and silver using the Yahoo Finance API.
+- [Activity Monitor](https://electronjs.org/blog/simple-samples#activity-monitor) - Shows a doughnut chart of the CPU system, user, and idle activity time.
+- [Hash](https://electronjs.org/blog/simple-samples#hash) - Shows the hash values of entered text using different algorithms.
+- [Prices](https://electronjs.org/blog/simple-samples#prices) - Shows the current price of oil, gold, and silver using the Yahoo Finance API.
 - [Touch Bar API](https://github.com/Rawnly/touchbar-api-sample) - Example of macOS Touch Bar integration.
 
 
@@ -329,8 +329,8 @@ Made with Electron.
 
 ## Documentation
 
-- [Quick Start](http://electron.atom.io/docs/tutorial/quick-start/)
-- [Official docs](http://electron.atom.io/docs/)
+- [Quick Start](https://electronjs.org/docs/tutorial/quick-start)
+- [Official docs](https://electronjs.org/docs)
 - [Essential Electron](http://jlord.us/essential-electron/) - Concise overview.
 
 


### PR DESCRIPTION
Updated links to the old domain electron.atom.io to https://electronjs.org.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
