### PR TITLE
Add Fenêtre to the list of closed source apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,7 @@ Made with Electron.
 - [CashNotify](https://cashnotify.com) - Monitor your Stripe accounts from your menu bar.
 - [Mockoon](https://mockoon.com) - Mock servers in seconds.
 - [Twitch](https://app.twitch.tv) - Official Twitch app.
+- [Fenêtre](https://fenêt.re) - Picture in picture for your Mac.
 
 ### Samples
 

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,7 @@ Made with Electron.
 - [CashNotify](https://cashnotify.com) - Monitor your Stripe accounts from your menu bar.
 - [Mockoon](https://mockoon.com) - Mock servers in seconds.
 - [Twitch](https://app.twitch.tv) - Official Twitch app.
-- [Fenêtre](https://fenêt.re) - Picture in picture for your Mac.
+- [Fenêtre](https://fenêt.re) - Picture-in-picture for your Mac.
 
 ### Samples
 


### PR DESCRIPTION
This is [Fenêtre](https://fenêt.re), trying to improve multitasking on the Mac by letting you have a picture in picture mode for any URL or file, being a picture, a video or a flat file.

Meaning that you can have any url, picture or video in a floating window that will stay in front of everything else at all time.

I wrote a 5 articles series about its conception and publishing on the AppStore.
[Here's the first one](https://hackernoon.com/electron-on-the-appstore-pain-tears-i-early-stages-7dcb85936f92), others are linked from there.

As a plus, here's my favorite feature.
![demo_small](https://user-images.githubusercontent.com/597828/33718933-67322ac2-db5f-11e7-9cd9-eeae1621625e.gif)

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
