### PR TITLE
Add Syng to list of open source apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [Comma Chameleon](https://github.com/theodi/comma-chameleon) - CSV editor.
 - [Buttercup Desktop](https://github.com/buttercup/buttercup-desktop) - Password manager.
 - [Mailspring](https://github.com/Foundry376/Mailspring) - Extensible email client. (Fork of Nylas Mail)
+- [Syng](https://github.com/sotch-pr35mac/syng) - Chinese-to-English dictionary and study tools.
 
 ### Closed Source
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Syng is a free, open source, and cross platform Chinese-to-English dictionary app and study toolset. Syng has been around for almost 2 years and works on Linux, macOS, and Windows. 

Homepage: [syngdict.com](http://www.syngdict.com/)

![homescreen](https://user-images.githubusercontent.com/441131/33799355-f0200d56-dcf7-11e7-9c35-7b9ac9458d59.png)

Thank you for your consideration!