### PR TITLE
Add Pomotroid

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
+- [Pomotroid](https://github.com/Splode/pomotroid) - Simple, configurable and visually-pleasing Pomodoro timer.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
-- [Pomotroid](https://github.com/Splode/pomotroid) - Simple, configurable and visually-pleasing Pomodoro timer.
+- [Pomotroid](https://github.com/Splode/pomotroid) - Pomodoro timer.
 
 ### Closed Source
 


### PR DESCRIPTION
Added Pomotroid, a simple and configurable Pomodoro timer to the 'Other' section. Pomotroid is open-source and has builds for Windows, Mac OS, and Debian/Ubuntu flavored Linux.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
