### PR TITLE
Add Mark Text

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
-- [MarkText](https://github.com/marktext/marktext) - Realtime preview Markdown editor. 
+- [Mark Text](https://github.com/marktext/marktext) - Real-time preview Markdown editor. 
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
+- [MarkText](https://github.com/marktext/marktext) - Realtime preview Markdown editor. 
 
 ### Closed Source
 


### PR DESCRIPTION
This PR will add **MarkText** to the list of Electron apps.

**Links**

Repo: https://github.com/marktext/marktext

Website: https://marktext.github.io/website/

Mark Text is a Markdown editor for Mac, It is a concise text editor, dedicated to improving your editing efficiency, enabling you to enjoy pleasure when you finish documents, novels and conference notes easily.

![](https://github.com/marktext/marktext/raw/master/doc/summary.jpg)

**Features**

- Realtime preview and use snabbdom as it's render engine.
- Support CommonMark Spec and GitHub Flavored Markdown Spec.
- Support paragraphs and inline style shortcuts to improve your writing efficiency.
- Output HTML and PDF file.
- Multiple themes.
- Various edit mode: Source Code mode、Typewriter mode、Focus mode.

**Source Code Mode**

![](https://marktext.github.io/website/img/source-code-mode.f48ea853.jpg)

**Focus Mode**

![](https://marktext.github.io/website/img/focus-mode.4a683a08.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sindresorhus/awesome-electron/522)
<!-- Reviewable:end -->
