### PR TITLE
Add electron-xiami

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
+- [electron-xiami](https://github.com/eNkru/electron-xiami) - Unofficial Xiami Player (虾米音乐) desktop for Linux & Mac
 
 ### Closed Source
 


### PR DESCRIPTION
[electron-xiami](https://github.com/eNkru/electron-xiami)

Xiami Online Player & Radio Desktop application for Linux & Mac users.

[README](https://github.com/eNkru/electron-xiami/blob/develop/README.en.md)

![linux_player_full](https://user-images.githubusercontent.com/13460738/38477881-769de2b6-3c09-11e8-8c75-75a13da42df2.png)

![linux_player_mini](https://user-images.githubusercontent.com/13460738/38477883-79400990-3c09-11e8-804f-b2e7bdd262fc.png)

![linux_player_radio](https://user-images.githubusercontent.com/13460738/38477885-7bd5355e-3c09-11e8-93a5-794250b5ceb9.png)

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
