### PR TITLE
add Markdown-Explorer to open source section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
+- [Markdown-Explorer](https://github.com/jersou/markdown-explorer) - Explore markdown documentation of a file tree.
 
 ### Closed Source
 


### PR DESCRIPTION

Markdown-Explorer app : https://github.com/jersou/markdown-explorer
![](https://raw.githubusercontent.com/jersou/markdown-explorer/master/doc/img/Markdown-Explorer.png)