### PR TITLE
Add electron-splashscreen

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -331,7 +331,7 @@ Made with Electron.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the macOS window titlebar.
 - [Brightwheel](https://github.com/loranallensmith/brightwheel) - Build and manage UI components with Photon and Etch.
 - [Xel](https://xel-toolkit.org) - Widget toolkit for building native-like apps.
-
+- [electron-splashscreen](https://github.com/trodi/electron-splashscreen) - Simple and smart splashscreen for your applications.
 
 ## Documentation
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

[electron-splashscreen](https://github.com/trodi/electron-splashscreen) has been released on `npm` for ~5 months and has been download a few hundred times. This component provides a splashscreen only when the app is taking too long to load. To quote the readme:

> Ideally, your application loads instantaneously. However, some applications are larger and/or may be running on a slower machine, causing the load to take longer. If the application is taking a bit to load, electron-splashscreen will appear so the user knows the application is loading, but can't interact with a partially loaded application.