### PR TITLE
Add Marp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ Made with Electron.
 - [Pretzel](https://github.com/amiechen/pretzel) - Show and search keyboard shortcuts for the current app.
 - [Netron](https://github.com/lutzroeder/netron) - Visualizer for deep learning and machine learning models.
 - [Ao](https://github.com/klauscfhq/ao) - Unofficial Microsoft To-Do app.
+- [Marp](https://github.com/yhatt/marp/) - Markdown presentation writer, powered by Electron.
 
 ### Closed Source
 


### PR DESCRIPTION
Added Marp, a Markdown presentation writer, powered by Electron.