### PR TITLE
Add electron-osx-prompt to 'Components' section.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -341,6 +341,7 @@ Made with Electron.
 - [titlebar](https://github.com/kapetan/titlebar) - Emulate the macOS window titlebar.
 - [Brightwheel](https://github.com/loranallensmith/brightwheel) - Build and manage UI components with Photon and Etch.
 - [Xel](https://xel-toolkit.org) - Widget toolkit for building native-like apps.
+- [electron-osx-prompt](https://github.com/peterfreeman/electron-osx-prompt) - Dialog box for macOS to prompt for user input.
 
 
 ## Documentation


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

The npm package `electron-osx-prompt` provides an easy API to prompt your macOS users for input while adapting to the macOS design. Electron itself prohibits the use of JavaScript's native `prompt()` method, so I developed this solution.