### PR TITLE
Add Noty

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ Made with Electron.
 - [Netron](https://github.com/lutzroeder/netron) - Visualizer for deep learning and machine learning models.
 - [Ao](https://github.com/klauscfhq/ao) - Unofficial Microsoft To-Do app.
 - [Etcher](https://github.com/resin-io/etcher) - Flash OS images to SD cards and USB drives.
+- [Noty](https://github.com/fabiospampinato/noty) - Autosaving sticky note with support for multiple notes without needing multiple windows.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ Made with Electron.
 - [Netron](https://github.com/lutzroeder/netron) - Visualizer for deep learning and machine learning models.
 - [Ao](https://github.com/klauscfhq/ao) - Unofficial Microsoft To-Do app.
 - [Etcher](https://github.com/resin-io/etcher) - Flash OS images to SD cards and USB drives.
-- [Noty](https://github.com/fabiospampinato/noty) - Autosaving sticky note with support for multiple notes without needing multiple windows.
+- [Noty](https://github.com/fabiospampinato/noty) - Auto-saving sticky note with support for multiple notes in a single window.
 
 ### Closed Source
 


### PR DESCRIPTION
[Noty](https://github.com/fabiospampinato/noty) - Autosaving sticky note with support for multiple notes without needing multiple windows.

I think it should be added because if you want a sticky-notes app for quickly annotating something then you'll probably want only one window rather than the gazillion ones one ends up having with other sticky-notes apps.

Some screenshots:

![](https://github.com/fabiospampinato/noty/raw/master/resources/demo/switching.gif)
![](https://github.com/fabiospampinato/noty/raw/master/resources/demo/creation.gif)