### PR TITLE
Add Altus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@ Made with Electron.
 - [Etcher](https://github.com/resin-io/etcher) - Flash OS images to SD cards and USB drives.
 - [Noty](https://github.com/fabiospampinato/noty) - Auto-saving sticky note with support for multiple notes in a single window.
 - [Notable](https://github.com/fabiospampinato/notable) - Markdown-based note-taking.
+- [Altus](https://github.com/shadythgod/altus) - Desktop client for WhatsApp with themes and multiple account support
 
 ### Closed Source
 


### PR DESCRIPTION
[Altus](https://github.com/ShadyThGod/altus) is a desktop client for WhatsApp with themes and multiple account support.

I think you should include this app because there aren't any other desktop WhatsApp clients that allow you to change themes and have multiple accounts

![](https://raw.githubusercontent.com/ShadyThGod/altus/master/img/Altus-Dark-Theme.png)