### PR TITLE
Rename `Backer Timetracker` to `Tockler`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ Made with Electron.
 - [Minira](https://github.com/jenslind/minira) - JIRA issues in your menubar.
 - [Ansel](https://github.com/m0g/ansel) - Image organizer.
 - [Build Checker App](https://github.com/willmendesneto/build-checker-app) - Check CI-server build statuses.
-- [Backer Timetracker](https://github.com/MayGo/backer-timetracker) - Tracks your time.
+- [Tockler](https://github.com/MayGo/tockler) - Tracks your time.
 - [Ghost](https://github.com/tryghost/ghost-desktop) - Professional publishing platform.
 - [Mattermost](https://github.com/mattermost/desktop) - Mattermost client.
 - [PupaFM](https://github.com/xwartz/PupaFM) - DoubanFM music player.


### PR DESCRIPTION
"Backer Timetracker" has changed the name to "Tockler" and moved the repo.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
