### PR TITLE
Add electron-chrome-extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,7 @@ Made with Electron.
 - [run-electron](https://github.com/sindresorhus/run-electron) - Run Electron without all the junk terminal output.
 - [ngx-electron](https://github.com/ThorstenHans/ngx-electron/) - Integrate Electron APIs and Angular.
 - [electron-ssl-pinning](https://github.com/dialogs/electron-ssl-pinning) - Prevent MITM.
+- [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome Extensions.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -314,7 +314,7 @@ Made with Electron.
 - [run-electron](https://github.com/sindresorhus/run-electron) - Run Electron without all the junk terminal output.
 - [ngx-electron](https://github.com/ThorstenHans/ngx-electron/) - Integrate Electron APIs and Angular.
 - [electron-ssl-pinning](https://github.com/dialogs/electron-ssl-pinning) - Prevent MITM.
-- [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome Extensions.
+- [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 
 ### Using Electron
 


### PR DESCRIPTION
Add [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension).

_electron-chrome-extension_ adds support for Chrome Extensions in Electron applications :)

----
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
