### PR TITLE
Add trilogy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -318,7 +318,7 @@ Made with Electron.
 - [electron-better-ipc](https://github.com/sindresorhus/electron-better-ipc) - Simplified IPC communication.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
-- [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ & pure JavaScript backends.
+- [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -318,6 +318,7 @@ Made with Electron.
 - [electron-better-ipc](https://github.com/sindresorhus/electron-better-ipc) - Simplified IPC communication.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
+- [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ & pure JavaScript backends.
 
 ### Using Electron
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

trilogy is a strongly typed layer for SQLite databases. It's especially great for Electron because it supports a pure JavaScript driver for SQLite ([sql.js](https://github.com/kripken/sql.js)) as well as the native C++ driver ([sqlite3](https://github.com/mapbox/sqlite3)). This means you can still use SQLite without the cross-platform compilation issues that can arise with `gyp` and other build tools, but switch at any time (eg. for performance benefits).

[citycide/trilogy](https://github.com/citycide/trilogy)