### PR TITLE
Added electron-nuxt boilerplate.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,7 @@ Made with Electron.
 - [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
 - [electron-sandbox](https://github.com/kewde/electron-sandbox) - Boilerplate and tutorial for creating secure apps (sandbox & communication over IPC).
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
+- [electron-nuxt](https://github.com/michalzaq12/electron-nuxt) - Quick start Nuxt.js / Vue.js boilerplate with vue-cli scaffolding and unit / e2e testing.
 
 
 ## Tools


### PR DESCRIPTION
Electron-nuxt is the boilerplate for making electron applications built with vue / nuxt.
Documentation: https://github.com/michalzaq12/electron-nuxt#documentation

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
