### PR TITLE
Add Laravel Kit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ Made with Electron.
 - [Mini Diary](https://github.com/samuelmeuli/mini-diary) - Simple and secure journal app.
 - [Unsplash Wallpapers](https://github.com/soroushchehresa/unsplash-wallpapers) - Set desktop wallpaper from Unsplash.
 - [Motrix](https://github.com/agalwood/Motrix) - Download manager.
+- [Laravel Kit](https://github.com/tmdh/laravel-kit) - Execute Laravel Artisan commands without using any terminal.
 
 ### Closed Source
 


### PR DESCRIPTION
Laravel Kit is a desktop application which can execute almost all Laravel Artisan commands without using any terminal.
[Laravel Kit on GitHub](https://github.com/tmdh/laravel-kit)

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
