### PR TITLE
Add electron-find

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,7 @@ Made with Electron.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
+- [electron-find](https://github.com/TheoXiong/electron-find) - Find all matches for the text in electron app.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -321,7 +321,7 @@ Made with Electron.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
-- [electron-find](https://github.com/TheoXiong/electron-find) - Find all matches for the text in electron app.
+- [electron-find](https://github.com/TheoXiong/electron-find) - Find all matches for the text in the web page.
 
 ### Using Electron
 


### PR DESCRIPTION
[electron-find](https://github.com/TheoXiong/electron-find)  is a search bar, used to find all matches for the text in the web page

![find](https://user-images.githubusercontent.com/42533484/62133649-b8567300-b311-11e9-9df9-a81d8002f57e.gif)


**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
