### PR TITLE
New app: ETCD-Manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ Made with Electron.
 - [Unsplash Wallpapers](https://github.com/soroushchehresa/unsplash-wallpapers) - Set desktop wallpaper from Unsplash.
 - [Motrix](https://github.com/agalwood/Motrix) - Download manager.
 - [Franz](https://github.com/meetfranz/franz) - Skype, Slack, Hangouts, WhatsApp, Grape, Telegram, FB Messenger, Hipchat in the same app.
-- [ETCD Manager](https://github.com/gtamas/etcdmanager) - A modern, efficient and free multi-platform ETCD GUI app based on Electron and VueJS
+- [ETCD Manager](https://github.com/icellmobilsoft/etcdmanager) - A modern, efficient and free multi-platform ETCD GUI app based on Electron and VueJS
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@ Made with Electron.
 - [Unsplash Wallpapers](https://github.com/soroushchehresa/unsplash-wallpapers) - Set desktop wallpaper from Unsplash.
 - [Motrix](https://github.com/agalwood/Motrix) - Download manager.
 - [Franz](https://github.com/meetfranz/franz) - Skype, Slack, Hangouts, WhatsApp, Grape, Telegram, FB Messenger, Hipchat in the same app.
+- [ETCD Manager](https://github.com/gtamas/etcdmanager) - A modern, efficient and free multi-platform ETCD GUI app based on Electron and VueJS
 
 ### Closed Source
 


### PR DESCRIPTION
I would like to add my open source app, ETCD Manager.

This is a modern and free ETCD (v3) GUI for Linux, Mac and Windows, written in Electron and VueJS. There are not many great GUIs for ETCD and most projects are old, even abandoned, so I think this app will be useful for all ETCD users.
Besides, currently there are appear to be no tools for ETCD in your list, so this would be the first one.

You may find the repo here:

https://github.com/gtamas/etcdmanager

Screenshots:

<img width="1792" alt="screen1" src="https://user-images.githubusercontent.com/687850/63052647-2db06f00-bee0-11e9-8443-4c0f8f9cd4e3.png">

<img width="1792" alt="screen3" src="https://user-images.githubusercontent.com/687850/63052690-46208980-bee0-11e9-9b62-b48cafd07991.png">

