### PR TITLE
Add adblocker-electron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -322,6 +322,7 @@ Made with Electron.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
+- [electron-adblocker](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Efficient and flexible adblocker library to easily block ads and trackers.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -322,7 +322,7 @@ Made with Electron.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
-- [electron-adblocker](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Block ads and trackers.
+- [adblocker-electron](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Block ads and trackers.
 
 ### Using Electron
 

--- a/readme.md
+++ b/readme.md
@@ -322,7 +322,7 @@ Made with Electron.
 - [electron-chrome-extension](https://github.com/getstation/electron-chrome-extension) - Add support for Chrome extensions.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
-- [electron-adblocker](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Efficient and flexible adblocker library to easily block ads and trackers.
+- [electron-adblocker](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Block ads and trackers.
 
 ### Using Electron
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

[electron-adblocker](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) is a battle-tested, efficient and flexible library allowing to block ads and trackers in any Electron app. It is very easy to get started but also allows advanced customization. Written in pure TypeScript, it does not require any compilation step during installation. Last but not least, there is currently no other library in the Electron ecosystem which allows to perform both network filtering and cosmetics injection using Easylist/uBlock Origin filters.

Here is a minimal example of how it can be used:

![electron-blocker](https://user-images.githubusercontent.com/1299873/64565525-403d8d00-d354-11e9-8bc0-7faf49908303.png)

Thanks a lot for maintaining this awesome list!