### PR TITLE
Add Gmail Desktop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@ Made with Electron.
 - [Unsplash Wallpapers](https://github.com/soroushchehresa/unsplash-wallpapers) - Set desktop wallpaper from Unsplash.
 - [Motrix](https://github.com/agalwood/Motrix) - Download manager.
 - [Franz](https://github.com/meetfranz/franz) - Skype, Slack, Hangouts, WhatsApp, Grape, Telegram, FB Messenger, Hipchat in the same app.
+- [Gmail Desktop](https://github.com/timche/gmail-desktop) - Unofficial Gmail app.
 
 ### Closed Source
 


### PR DESCRIPTION
[Gmail Desktop](https://github.com/timche/gmail-desktop) brings Gmail to the desktop while keeping its original interface but with a more native experience. Additionally it offers [appearance customizations](https://github.com/timche/gmail-desktop#appearance-customizations), desktop notifications, unread badges and more. This project has been inspired by Caprine to create a simple but yet powerful desktop app which the browser counterpart can't provide.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**