### PR TITLE
fix: Update Upterm to Hyper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Made with Electron.
 - [Nocturn](https://github.com/k0kubun/Nocturn) - Twitter client.
 - [Mojibar](https://github.com/muan/mojibar) - Emoji searcher in your menubar.
 - [Playback](https://github.com/mafintosh/playback) - Video player.
-- [Upterm](https://github.com/railsware/upterm) - Terminal.
+- [hyper](https://github.com/zeit/hyper) - Terminal.
 - [Atom](https://github.com/atom/atom) - Code editor.
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Cross-platform IDE.
 - [Wexond](https://github.com/sential/wexond) - Web browser with material UI and extensions API.


### PR DESCRIPTION
Upterm has been deprecated in favor of Hyper which is also
an Electron app. Update the link to point to Hyper's Github repo.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
