### PR TITLE
Add MQTTX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Made with Electron.
 - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 - [massCode](https://github.com/antonreshetov/massCode) - Code snippet manager for developers.
 - [Swifty](https://github.com/swiftyapp/swifty) - Password manager.
+- [MQTTX](https://github.com/emqx/MQTTX) - MQTT desktop client
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Made with Electron.
 - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 - [massCode](https://github.com/antonreshetov/massCode) - Code snippet manager for developers.
 - [Swifty](https://github.com/swiftyapp/swifty) - Password manager.
-- [MQTTX](https://github.com/emqx/MQTTX) - An elegant cross-platform MQTT 5.0 desktop client
+- [MQTTX](https://github.com/emqx/MQTTX) - MQTT 5.0 desktop client. (MQTT stands for MQ Telemetry Transport. It is a publish/subscribe, extremely simple and lightweight messaging protocol)
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Made with Electron.
 - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 - [massCode](https://github.com/antonreshetov/massCode) - Code snippet manager for developers.
 - [Swifty](https://github.com/swiftyapp/swifty) - Password manager.
-- [MQTTX](https://github.com/emqx/MQTTX) - MQTT 5.0 desktop client. (MQTT stands for MQ Telemetry Transport. It is a publish/subscribe, extremely simple and lightweight messaging protocol)
+- [MQTTX](https://github.com/emqx/MQTTX) - Client for MQTT, which is a lightweight messaging protocol.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Made with Electron.
 - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 - [massCode](https://github.com/antonreshetov/massCode) - Code snippet manager for developers.
 - [Swifty](https://github.com/swiftyapp/swifty) - Password manager.
-- [MQTTX](https://github.com/emqx/MQTTX) - MQTT desktop client
+- [MQTTX](https://github.com/emqx/MQTTX) - An elegant cross-platform MQTT 5.0 desktop client
 
 ### Closed Source
 


### PR DESCRIPTION
**Description**: 

MQTTX is a MQTT desktop client open sourced by EMQ, It allows users to quickly test the MQTT/MQTTS connection, publish and subscribe to MQTT messages.
It's built with `Electron` & `Vue` & `TypeScript`. You can learn how to use electron in Vue and typescript.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
