### PR TITLE
Add electron-create-menu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,7 @@ Made with Electron.
 - [electron-ipc-proxy](https://github.com/frankwallis/electron-ipc-proxy) - Transparent asynchronous remoting between browser windows and the main process.
 - [trilogy](https://github.com/citycide/trilogy) - TypeScript SQLite database layer with support for both native C++ and pure JavaScript backends.
 - [adblocker-electron](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) - Block ads and trackers.
+- [electron-create-menu](https://github.com/kilian/electron-create-menu) - Default menus for all platforms, easily extendable and with i18n support.
 
 ### Using Electron
 


### PR DESCRIPTION
The electron-create-menu package replaces the Electron menu API with one that makes it easy to create specific menus for each platform and translate them, as well as providing solid defaults for each platform. 