### PR TITLE
Add HTTP Toolkit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@ Made with Electron.
 - [Franz](https://github.com/meetfranz/franz) - Skype, Slack, Hangouts, WhatsApp, Grape, Telegram, FB Messenger, Hipchat in the same app.
 - [Gmail Desktop](https://github.com/timche/gmail-desktop) - Unofficial Gmail app.
 - [Upcount](https://github.com/madisvain/upcount) - Invoicing.
+- [HTTP Toolkit](https://httptoolkit.tech) - HTTP debugging & mocking tool.
 
 ### Closed Source
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

[HTTP Toolkit](https://httptoolkit.tech) is an open-source Electron-based developer tool, similar to closed-source apps like Fiddler & Charles (but modern, open-source, cross-platform, user-friendly and generally better).

I've linked to the main project page rather than github since there's no single github repo as such. It's built in a few parts, they're all visible here: https://github.com/httptoolkit/. Happy to swap for that if GH links are required for open-source projects.