### PR TITLE
Add ExifCleaner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@ Made with Electron.
 - [Franz](https://github.com/meetfranz/franz) - Skype, Slack, Hangouts, WhatsApp, Grape, Telegram, FB Messenger, Hipchat in the same app.
 - [Gmail Desktop](https://github.com/timche/gmail-desktop) - Unofficial Gmail app.
 - [Upcount](https://github.com/madisvain/upcount) - Invoicing.
+- [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 
 ### Closed Source
 


### PR DESCRIPTION
ExifCleaner is a drag and drop GUI to remove image metadata. I think it's worth including because it's simple, it works, it's free, and I couldn't find anything else that did the same thing. I've been using it for more than a month and have fixed all the bugs that myself and other users (at least one from each platform of Windows, Linux, and Mac) have encountered during that time.

Github: https://github.com/szTheory/exifcleaner
Website: https://exifcleaner.com

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**