### PR TITLE
Add Unicopedia Plus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,7 @@ Made with Electron.
 - [Upcount](https://github.com/madisvain/upcount) - Invoicing.
 - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Clean image metadata with drag and drop.
 - [massCode](https://github.com/antonreshetov/massCode) - Code snippet manager for developers.
+- [Unicopedia Plus](https://github.com/tonton-pixel/unicopedia-plus) - Developer-oriented set of Unicode, Unihan & emoji utilities.
 
 ### Closed Source
 


### PR DESCRIPTION
[Unicopedia Plus](https://github.com/tonton-pixel/unicopedia-plus) is a developer-oriented set of Unicode, Unihan & emoji utilities wrapped into one single desktop application, built with [Electron](https://electronjs.org/). Its code is open-source (MIT license) and it runs on macOS, Linux and Windows operating systems. A macOS binary is directly available from its GitHub repository's [releases](https://github.com/tonton-pixel/unicopedia-plus/releases) page.

GitHub: https://github.com/tonton-pixel/unicopedia-plus

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
