### PR TITLE
Updating secure boilerplate with new template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Made with Electron.
 - [bozon](https://github.com/railsware/bozon) - Scaffold, run, test, and package your app.
 - [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
 - [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
-- [electron-sandbox](https://github.com/kewde/electron-sandbox) - Boilerplate and tutorial for creating secure apps (sandbox & communication over IPC).
+- [secure-electron-template](https://github.com/reZach/secure-electron-template) - Boilerplate for creating secure apps - by [reZach](https://github.com/reZach).
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
 
 ## Tools

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Made with Electron.
 - [bozon](https://github.com/railsware/bozon) - Scaffold, run, test, and package your app.
 - [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
 - [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
-- [secure-electron-template](https://github.com/reZach/secure-electron-template) - Boilerplate for creating secure apps - by [reZach](https://github.com/reZach).
+- [secure-electron-template](https://github.com/reZach/secure-electron-template) - Boilerplate for creating secure apps.
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
 
 ## Tools


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

The owner of **electron-sandbox-boilerplate** (who is listed on the readme) [is suggesting](https://github.com/kewde/electron-sandbox-boilerplate/issues/14#issuecomment-579554998) to have people use [my template](https://github.com/reZach/secure-electron-template) over his, as his template is a bit outdated. To this end, I've updated the readme to point to [`secure-electron-template`](https://github.com/reZach/secure-electron-template).

This project is [older than 30 days](https://github.com/reZach/secure-electron-template/graphs/contributors) and I intend to use it for professional means. It also has over 210 stars.

I understand this doesn't fit the guidelines but I thought this could be an exception. If you do not want this change, please close/abandon this PR.