### PR TITLE
Add RxDB

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -287,7 +287,7 @@ Made with Electron.
 - [electron-context-menu](https://github.com/sindresorhus/electron-context-menu) - Extensible context menu.
 - [electron-require](https://github.com/brrd/electron-require) - Simplified require.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in-memory database.
-- [RxDB](https://github.com/pubkey/rxdb) - A realtime NoSQL Database for UI-based Applications.
+- [RxDB](https://github.com/pubkey/rxdb) - A realtime NoSQL database.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
 - [electron-log](https://github.com/megahertz/electron-log) - Simple logging.
 - [electron-redux](https://github.com/hardchor/electron-redux) - Synchronize Redux state across windows.

--- a/readme.md
+++ b/readme.md
@@ -287,6 +287,7 @@ Made with Electron.
 - [electron-context-menu](https://github.com/sindresorhus/electron-context-menu) - Extensible context menu.
 - [electron-require](https://github.com/brrd/electron-require) - Simplified require.
 - [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent or in-memory database.
+- [RxDB](https://github.com/pubkey/rxdb) - A realtime NoSQL Database for UI-based Applications.
 - [electron-devtools-installer](https://github.com/GPMDP/electron-devtools-installer) - Install DevTools extensions from the Chrome Web Store.
 - [electron-log](https://github.com/megahertz/electron-log) - Simple logging.
 - [electron-redux](https://github.com/hardchor/electron-redux) - Synchronize Redux state across windows.


### PR DESCRIPTION
This adds RxDB to the list. RxDB is a realtime database which works great with electron. Also it has [two example](https://github.com/pubkey/rxdb/tree/master/examples/electron) projects that show how it can be used with electron.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
