### PR TITLE
Electron Gatsby Boilerplate Added

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,7 @@ Made with Electron.
 - [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
 - [secure-electron-template](https://github.com/reZach/secure-electron-template) - Security-focused boilerplate for creating apps with React, Redux, Webpack, and i18next.
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
+- [electron-gatsby-boilerplate](https://github.com/zonayedpca/electron-gatsby-boilerplate) - Boilerplate to build your app with Gatsby. Supports Redux, Hot Reload, Automatic Deployment and Automatic Linting.
 
 ## Tools
 


### PR DESCRIPTION
I have added this boilerplate which let us create Electron App with the popular React-based Framework Gatsby.

Although my repo doesn't have 30+ stars, I think it can be useful for all the developers around working with Electron. The addition of Gatsby will allow them to make new BrowserWindow comfortably...

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
