### PR TITLE
Remove Inboxer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,6 @@ Made with Electron.
 - [Manta](https://github.com/hql287/Manta) - Invoicing for freelancers with beautiful and customizable templates.
 - [Headset](https://github.com/headsetapp/headset-electron) - Discover, collect, and listen to music from YouTube.
 - [Nuclear](https://github.com/nukeop/nuclear) - Music player that streams from free sources.
-- [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox app.
 - [FreeMAN](https://github.com/matthew-matvei/freeman) - File manager for power users.
 - [Mark Text](https://github.com/marktext/marktext) - Real-time preview Markdown editor.
 - [Pomotroid](https://github.com/Splode/pomotroid) - Pomodoro timer.


### PR DESCRIPTION
Hi Sindre!

It looks like the [Inboxer](https://github.com/denysdovhan/inboxer) project has been deprecated and archived. I think it should be removed from the list because it is no longer maintained.