### PR TITLE
Fix podcast link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -428,7 +428,7 @@ Made with Electron.
 - [JavaScript Jabber: Electron with Jessica Lord and Amy Palamountain](https://devchat.tv/js-jabber/193-jsj-electron-with-jessica-lord-and-amy-palamountain)
 - [Hanselminutes: Creating cross-platform Electron apps with Jessica Lord](http://hanselminutes.com/534/creating-cross-platform-electron-apps-with-jessica-lord)
 - [JavaScript Air: Electron Apps with @jlord and @emorikawa](https://javascriptair.com/episodes/2016-07-06)
-- [The Changelog #216: GitHub's Electron with Zeke Sikelianos](https://changelog.com/216/)
+- [The Changelog #216: GitHub's Electron with Zeke Sikelianos](https://changelog.com/podcast/216)
 - [Full Stack Radio #48: Jessica Lord - Building Desktop Apps with Electron](http://www.fullstackradio.com/48)
 
 ## Community


### PR DESCRIPTION
Hey,

fixing a link to the podcast on changelog here:

[old](https://changelog.com/216/) vs. [new](https://changelog.com/podcast/216/) 

Cheers!