### PR TITLE
Add Nota

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,7 @@ Made with Electron.
 - [Taskade](https://www.taskade.com) - Realtime organization and collaboration tool for distributed teams with tasks, notes, and chat.
 - [Coloban](https://www.coloban.com) - All-in-one project management tool with chats, Kanban, Gantt, calls, screenshare, and more.
 - [Dynobase](https://dynobase.dev) - AWS DynamoDB GUI.
+- [Nota](https://nota.md) - Pro writing app designed for local Markdown files.
 
 ### Samples
 


### PR DESCRIPTION
[Nota](https://nota.md) is a writing app designed for local Markdown files. It's aimed at developers with IDE-like features and users that are building their own personal knowledge bases with features like wiki-links and backlinks.

We don't have a blog post describing our technology stack(we should) but I will try to provide proof it's built with Electron:
- if you download the app from https://github.com/notaapp/releases/releases/tag/0.23.1 you will see the size and its contents
- if you don't want to do it here is the contents of the Nota folder: 
![image](https://user-images.githubusercontent.com/884810/110131682-1511ed80-7dd3-11eb-8209-954c5606f465.png)
