### PR TITLE
Update boilerplates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Electron is an open-source framework for creating desktop apps using web technol
 
 ---
 
-<div style="text-align:center;">
+<div align="center">
 	<p>
 		<p>
 			<sup>
@@ -282,6 +282,8 @@ Made with Electron.
 
 ## Boilerplates
 
+- [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) - Boilerplate to kickstart creating an app - by [sindresorhus](http://github.com/sindresorhus).
+- [generator-electron](https://github.com/sindresorhus/generator-electron) - Scaffold out an app boilerplate.
 - [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) - Comprehensive boilerplate which even generates installers - by [szwacz](https://github.com/szwacz).
 - [electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate) - Boilerplate based on React and webpack.
 - [electron-quick-start](https://github.com/electron/electron-quick-start) - Clone the repo to try a simple app.
@@ -289,15 +291,6 @@ Made with Electron.
 - [secure-electron-template](https://github.com/reZach/secure-electron-template) - Security-focused boilerplate for creating apps with React, Redux, Webpack, and i18next.
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
 - [vite-electron-builder](https://github.com/cawa-93/vite-electron-builder) - Secure boilerplate for Electron app based on Vite. TypeScript + Vue/React/Angular/Svelte/Vanilla.
-
-### Outdated
-These boilerplates are currently using versions of Electron that [are not supported](https://www.electronjs.org/docs/tutorial/support#currently-supported-versions).
-
-- [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) - Boilerplate to kickstart creating an app - by [sindresorhus](http://github.com/sindresorhus).
-- [generator-electron](https://github.com/sindresorhus/generator-electron) - Scaffold out an app boilerplate.
-- [descjop](https://github.com/karad/lein_template_descjop) - ClojureScript boilerplate for creating an app.
-- [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
-- [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
 
 ## Tools
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Electron is an open-source framework for creating desktop apps using web technol
 
 ---
 
-<div align="center">
+<div style="text-align:center;">
 	<p>
 		<p>
 			<sup>
@@ -282,17 +282,22 @@ Made with Electron.
 
 ## Boilerplates
 
-- [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) - Boilerplate to kickstart creating an app - by [sindresorhus](http://github.com/sindresorhus).
-- [generator-electron](https://github.com/sindresorhus/generator-electron) - Scaffold out an app boilerplate.
 - [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) - Comprehensive boilerplate which even generates installers - by [szwacz](https://github.com/szwacz).
 - [electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate) - Boilerplate based on React and webpack.
-- [descjop](https://github.com/karad/lein_template_descjop) - ClojureScript boilerplate for creating an app.
 - [electron-quick-start](https://github.com/electron/electron-quick-start) - Clone the repo to try a simple app.
 - [bozon](https://github.com/railsware/bozon) - Scaffold, run, test, and package your app.
-- [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
-- [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
 - [secure-electron-template](https://github.com/reZach/secure-electron-template) - Security-focused boilerplate for creating apps with React, Redux, Webpack, and i18next.
 - [angular-electron](https://github.com/maximegris/angular-electron) - Fast bootstrapping with Angular, Electron, TypeScript, SASS, and Hot Reload.
+- [vite-electron-builder](https://github.com/cawa-93/vite-electron-builder) - Secure boilerplate for Electron app based on Vite. TypeScript + Vue/React/Angular/Svelte/Vanilla.
+
+### Outdated
+These boilerplates are currently using versions of Electron that [are not supported](https://www.electronjs.org/docs/tutorial/support#currently-supported-versions).
+
+- [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) - Boilerplate to kickstart creating an app - by [sindresorhus](http://github.com/sindresorhus).
+- [generator-electron](https://github.com/sindresorhus/generator-electron) - Scaffold out an app boilerplate.
+- [descjop](https://github.com/karad/lein_template_descjop) - ClojureScript boilerplate for creating an app.
+- [electron-vue](https://github.com/SimulatedGREG/electron-vue) - Easily build your app with Vue and common plugins.
+- [electron-next-skeleton](https://github.com/leo/electron-next-skeleton) - Boilerplate to build your app with Next.js.
 
 ## Tools
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

There are a number of boilerplates that are running old versions of Electron that are [not currently supported](https://www.electronjs.org/docs/tutorial/support#currently-supported-versions). It is better that the community use maintained templates such that best-practices are followed in new Electron apps. I have no authority to _remove_ them, so I thought it would make sense to put them under a **Outdated** header.

Additionally, [vite-electron-builder](https://github.com/cawa-93/vite-electron-builder) (Vue; 167 stars) seems to be a good substitute to the already-existing [electron-vue](https://github.com/SimulatedGREG/electron-vue) which doesn't seem as maintained.

A good majority of Electron frameworks were recently [reviewed by me](https://github.com/reZach/secure-electron-template/wiki/State-of-Electron-frameworks-%5BMay-2021%5D) and I thought my findings could find a place on this repo.

Also, _minor_ css fix as my linter was complaining viewing the readme 👍 .