### PR TITLE
Add Heroic Games Launcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,7 @@ Made with Electron.
 - [Graviton Editor](https://github.com/Graviton-Code-Editor/Graviton-App) - Cross-platform code editor.
 - [Yana](https://github.com/lukasbach/yana) - Notebook app with rich-text notes, nested note organization and global search.
 - [SpaceEye](https://github.com/KYDronePilot/SpaceEye) - Live satellite imagery for your desktop background.
+- [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher) - An alternative Epic games launcher for Linux, Windows and Mac.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,7 @@ Made with Electron.
 - [Graviton Editor](https://github.com/Graviton-Code-Editor/Graviton-App) - Cross-platform code editor.
 - [Yana](https://github.com/lukasbach/yana) - Notebook app with rich-text notes, nested note organization and global search.
 - [SpaceEye](https://github.com/KYDronePilot/SpaceEye) - Live satellite imagery for your desktop background.
-- [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher) - An alternative Epic games launcher for Linux, Windows and Mac.
+- [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher) - Alternative Epic games launcher.
 
 ### Closed Source
 


### PR DESCRIPTION
Heroic Games Launcher is a GPL3 app made with Electron for Linux, Windows and Mac as an alternative to the official Epic Games Launcher.

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
