### PR TITLE
Add Browserosaurus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,7 @@ Made with Electron.
 - [SpaceEye](https://github.com/KYDronePilot/SpaceEye) - Live satellite imagery for your desktop background.
 - [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher) - Alternative Epic games launcher.
 - [VIR](https://github.com/TommyX12/VIR) - Intelligent time manager with automatic planning.
+- [Browserosaurus](https://github.com/will-stone/browserosaurus) - Browser prompter for macOS.
 
 ### Closed Source
 


### PR DESCRIPTION
https://github.com/will-stone/browserosaurus

Hi Sindre 👋 

Browserosaurus is an open-source browser prompter for macOS. It works by setting itself as the default browser; any clicked links in non-browser apps are now sent to Browserosaurus where you are presented with a menu of all your installed browsers. You may now decide which app you’d like to continue opening the link with.

Browserosaurus has been a side-project of mine for over 4 years now. It's been great fun developing the UX over all that time, and learning (and coping with) all the nuances that come with Electron. But I'm pleased I could use my JS skills to create an app that I (and many others) use many times everyday.

It's currently up 737 stars. I'd be proud to see my little app on the Awesome list 🙂 

Thanks,

Will.