### PR TITLE
Add shadowsocks-electron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,7 +254,7 @@ Made with Electron.
 - [VIR](https://github.com/TommyX12/VIR) - Intelligent time manager with automatic planning.
 - [Browserosaurus](https://github.com/will-stone/browserosaurus) - Browser prompter for macOS.
 - [linked](https://github.com/lostdesign/linked) - Daily journal.
-- [shadowsocks-electron](https://github.com/nojsja/shadowsocks-electron) - Cross-platform Shadowsocks GUI client.
+- [shadowsocks-electron](https://github.com/nojsja/shadowsocks-electron) - Cross-platform Shadowsocks client.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,7 @@ Made with Electron.
 - [VIR](https://github.com/TommyX12/VIR) - Intelligent time manager with automatic planning.
 - [Browserosaurus](https://github.com/will-stone/browserosaurus) - Browser prompter for macOS.
 - [linked](https://github.com/lostdesign/linked) - Daily journal.
+- [shadowsocks-electron](https://github.com/nojsja/shadowsocks-electron) - Cross-platform Shadowsocks GUI client.
 
 ### Closed Source
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Hello maintainers.

Shadowsocks is a fast tunnel proxy that helps users bypass firewalls and shadowsocks-electron provides a GUI client for easy to use it. I developed and tested it on multi operating systems especially Ubuntu which users always fall into complicated proxy configaration.