### PR TITLE
Add Ostara app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ Made with Electron.
 - [Browserosaurus](https://github.com/will-stone/browserosaurus) - Browser prompter for macOS.
 - [linked](https://github.com/lostdesign/linked) - Daily journal.
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager.
-- [Ostara](https://github.com/krud-dev/ostara) - Management tool that provides various features to monitor and interact with Spring Boot Applications via Actuator.
+- [Ostara](https://github.com/krud-dev/ostara) - Monitor and interact with Spring Boot apps via Actuator.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,7 @@ Made with Electron.
 - [Browserosaurus](https://github.com/will-stone/browserosaurus) - Browser prompter for macOS.
 - [linked](https://github.com/lostdesign/linked) - Daily journal.
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager.
+- [Ostara](https://github.com/krud-dev/ostara) - Management tool that provides various features to monitor and interact with Spring Boot Applications via Actuator.
 
 ### Closed Source
 


### PR DESCRIPTION
Ostara is a split Electron/Spring Boot app intended to be used as a visual management tool for other Spring apps.

Link to repo: https://github.com/krud-dev/ostara
Documentation site: https://docs.ostara.dev/