### PR TITLE
Add PikaTorrent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ Made with Electron.
 - [shadowsocks-electron](https://github.com/nojsja/shadowsocks-electron) - Cross-platform Shadowsocks client.
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager.
 - [Ostara](https://github.com/krud-dev/ostara) - Monitor and interact with Spring Boot apps via Actuator.
+- [PikaTorrent](https://github.com/G-Ray/pikatorrent) - Modern, simple, connected, and electric BitTorrent app.
 
 ### Closed Source
 

--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ Made with Electron.
 - [shadowsocks-electron](https://github.com/nojsja/shadowsocks-electron) - Cross-platform Shadowsocks client.
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager.
 - [Ostara](https://github.com/krud-dev/ostara) - Monitor and interact with Spring Boot apps via Actuator.
-- [PikaTorrent](https://github.com/G-Ray/pikatorrent) - Modern, simple, connected, and electric BitTorrent app.
+- [PikaTorrent](https://github.com/G-Ray/pikatorrent) - BitTorrent client.
 
 ### Closed Source
 


### PR DESCRIPTION
Website: [www.pikatorrent.com](https://www.pikatorrent.com)
Github: [github.com/G-Ray/pikatorrent](https://github.com/G-Ray/pikatorrent)

A BitTorrent app available on desktop (electron), mobile, & even as a cli on `npm`.