### PR TITLE
feat(tools): add  electron-vite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -287,6 +287,7 @@ Made with Electron.
 - [pluggable-electron](https://github.com/dutchigor/pluggable-electron) - Build apps that can be extended through plugins.
 - [Hydraulic Conveyor](https://hydraulic.dev) - CLI tool that deploys apps without needing any special update servers, multi-platform CI, or code changes.
 - [Aptabase](https://aptabase.com/for-electron) - Analytics for apps. Open source, privacy-friendly, and simple.
+- [electron-vite](https://github.com/electron-vite) - Using Vite and Electron to build desktop App quickly.
 
 ### Using Electron
 


### PR DESCRIPTION
- [electron-vite-react/releases](https://github.com/electron-vite/electron-vite-react/releases/tag/v0.9.9)You can download programs for macOS, Linux, and Windows.It may not be the latest version because the latest version of the program is compatible electron`@28.x` And `vite@5.x` I currently do not have a Mac computer to build it and upload it. But the functionality is consistent, just to make it better.
- Actually, I think it should be in the Electron template category, although it also has separate plugins to make users more flexible. (But it seems that the template classification has been temporarily suspended for acceptance).
- This is a screenshot of the latest version of the product:
![image](https://github.com/sindresorhus/awesome-electron/assets/81673017/91a8c6d8-a4fa-48e7-ae67-716c8338d197)
