### PR TITLE
Add SiteOne Crawler (website analyzer and exporter)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Made with Electron.
 - [Ostara](https://github.com/krud-dev/ostara) - Monitor and interact with Spring Boot apps via Actuator.
 - [PikaTorrent](https://github.com/G-Ray/pikatorrent) - BitTorrent client.
 - [Wave Terminal](https://github.com/wavetermdev/waveterm) - Open-source terminal with AI integration.
+- [SiteOne Crawler](https://github.com/janreges/siteone-crawler-gui) - Cross-platform website analyzer (SEO, security, accessibility, performance) and cloner.
 
 ### Closed Source
 


### PR DESCRIPTION
I have created an in-depth open-source website analyzer (SEO, security, performance, accessibility) and exporter, which is a nice and useful use-case for Electron, combined with Svelte.

This PR adds this tool (SiteOne Crawler) to README.md.

In the README.md I refer to the GitHub repository, but here is also the homepage of this tool, where there is detailed documentation - https://crawler.siteone.io/

![SiteOne Crawler](https://github.com/janreges/siteone-crawler-gui/raw/master/docs/app-demo-2023-12-04.gif)

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
