### PR TITLE
Add Maestro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,7 @@ Made with Electron.
 - [PikaTorrent](https://github.com/G-Ray/pikatorrent) - BitTorrent client.
 - [Wave Terminal](https://github.com/wavetermdev/waveterm) - Open-source terminal with AI integration.
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - Companion desktop app for Signal mobile app.
+- [Maestro](https://github.com/pedramamini/Maestro) - Manage multiple AI coding assistants simultaneously with a keyboard-first interface.
 
 ### Closed Source
 


### PR DESCRIPTION
[Maestro](https://github.com/pedramamini/Maestro) is an Electron desktop app for managing multiple AI coding assistants (Claude Code, OpenAI Codex, Gemini CLI) simultaneously with a keyboard-first interface.

### Why it should be included
- Open source with 250+ stars
- Unique multi-agent management experience for developers
- Active development with regular releases
- Compiled binaries available for macOS

### Checklist
- [x] 40+ stars
- [x] 30+ days old
- [x] English readme with screenshots
- [x] Open source
- [x] Compiled binaries